### PR TITLE
Add xsd schema to jmef format

### DIFF
--- a/jmef.xsd
+++ b/jmef.xsd
@@ -1,0 +1,1839 @@
+i<?xml version="1.0" encoding="utf-8"?>
+<xs:schema
+	xmlns:xlink="http://www.w3.org/1999/xlink" attributeFormDefault="unqualified" elementFormDefault="qualified"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:import schemaLocation="https://www.w3.org/1999/xlink.xsd" namespace="http://www.w3.org/1999/xlink" />
+	<xs:element name="journal">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element maxOccurs="unbounded" name="journal-id">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="journal-id-type" type="xs:string" use="required" />
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="journal-title-group">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="journal-title" type="xs:string" />
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element maxOccurs="unbounded" name="issn">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="publication-format" type="xs:string" use="required" />
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="publisher">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="publisher-name" type="xs:string" />
+							<xs:element name="publisher-location">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="country">
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:string">
+														<xs:attribute name="iso2" type="countryIso2Type" use="optional" />
+														<xs:attribute name="iso3" type="xs:string" use="optional" />
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="publication-policy">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="costs">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="apc">
+											<xs:complexType>
+												<xs:attribute name="present" type="xs:boolean" use="required" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="other-charges">
+											<xs:complexType>
+												<xs:attribute name="present" type="xs:boolean" use="required" />
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="review-process">
+								<xs:complexType>
+									<xs:attribute name="peer-review" type="xs:boolean" use="required" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="languages">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element maxOccurs="unbounded" name="language">
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:string">
+														<xs:attribute name="iso1" type="languageIso1Type" use="optional" />
+														<xs:attribute name="iso2" type="languageIso2Type" use="optional" />
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="licenses">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element maxOccurs="unbounded" name="license">
+											<xs:complexType>
+												<xs:attribute ref="xlink:href" use="required" />
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="authorship">
+								<xs:complexType>
+									<xs:attribute name="open" type="xs:boolean" use="required" />
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="self-uri">
+					<xs:complexType>
+						<xs:attribute ref="xlink:href" use="required" />
+					</xs:complexType>
+				</xs:element>
+				<xs:element maxOccurs="unbounded" name="kwd-group">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element minOccurs="0" name="compound-kwd">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element maxOccurs="unbounded" name="compound-kwd-part">
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:string">
+														<xs:attribute name="content-type" type="xs:string" use="required" />
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element minOccurs="0" maxOccurs="unbounded" name="kwd" type="xs:string" />
+						</xs:sequence>
+						<xs:attribute name="vocab" type="xs:string" use="optional" />
+						<xs:attribute name="vocab-identifier" type="xs:string" use="optional" />
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="owner-type" type="xs:string" use="optional" />
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="countryIso2Type" id="countryIso2Type">
+		<xs:annotation>
+			<xs:documentation>Two-letter ISO 3166-1 alpha-2 country code.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<!-- Andorra -->
+			<xs:enumeration value="AD" />
+			<!-- United Arab Emirates -->
+			<xs:enumeration value="AE" />
+			<!-- Afghanistan -->
+			<xs:enumeration value="AF" />
+			<!-- Antigua and Barbuda -->
+			<xs:enumeration value="AG" />
+			<!-- Anguilla -->
+			<xs:enumeration value="AI" />
+			<!-- Albania -->
+			<xs:enumeration value="AL" />
+			<!-- Armenia -->
+			<xs:enumeration value="AM" />
+			<!-- Angola -->
+			<xs:enumeration value="AO" />
+			<!-- Antarctica -->
+			<xs:enumeration value="AQ" />
+			<!-- Argentina -->
+			<xs:enumeration value="AR" />
+			<!-- American Samoa -->
+			<xs:enumeration value="AS" />
+			<!-- Austria -->
+			<xs:enumeration value="AT" />
+			<!-- Australia -->
+			<xs:enumeration value="AU" />
+			<!-- Aruba -->
+			<xs:enumeration value="AW" />
+			<!-- Åland Islands (An autonomous county of Finland) -->
+			<xs:enumeration value="AX" />
+			<!-- Azerbaijan -->
+			<xs:enumeration value="AZ" />
+			<!-- Bosnia and Herzegovina -->
+			<xs:enumeration value="BA" />
+			<!-- Barbados -->
+			<xs:enumeration value="BB" />
+			<!-- Bangladesh -->
+			<xs:enumeration value="BD" />
+			<!-- Belgium -->
+			<xs:enumeration value="BE" />
+			<!-- Burkina Faso -->
+			<xs:enumeration value="BF" />
+			<!-- Bulgaria -->
+			<xs:enumeration value="BG" />
+			<!-- Bahrain -->
+			<xs:enumeration value="BH" />
+			<!-- Burundi -->
+			<xs:enumeration value="BI" />
+			<!-- Benin -->
+			<xs:enumeration value="BJ" />
+			<!-- Saint Barthélemy -->
+			<xs:enumeration value="BL" />
+			<!-- Bermuda -->
+			<xs:enumeration value="BM" />
+			<!-- Brunei Darussalam -->
+			<xs:enumeration value="BN" />
+			<!-- Bolivia (Plurinational State of) -->
+			<xs:enumeration value="BO" />
+			<!-- Bonaire, Sint Eustatius and Saba (Part of the Netherlands) -->
+			<xs:enumeration value="BQ" />
+			<!-- Brazil -->
+			<xs:enumeration value="BR" />
+			<!-- Bahamas -->
+			<xs:enumeration value="BS" />
+			<!-- Bhutan -->
+			<xs:enumeration value="BT" />
+			<!-- Bouvet Island (Dependency of Norway) -->
+			<xs:enumeration value="BV" />
+			<!-- Botswana -->
+			<xs:enumeration value="BW" />
+			<!-- Belarus -->
+			<xs:enumeration value="BY" />
+			<!-- Belize -->
+			<xs:enumeration value="BZ" />
+			<!-- Canada -->
+			<xs:enumeration value="CA" />
+			<!-- Cocos (Keeling) Islands (External territory of Australia) -->
+			<xs:enumeration value="CC" />
+			<!-- Congo, Democratic Republic of the -->
+			<xs:enumeration value="CD" />
+			<!-- Central African Republic -->
+			<xs:enumeration value="CF" />
+			<!-- Congo -->
+			<xs:enumeration value="CG" />
+			<!-- Switzerland -->
+			<xs:enumeration value="CH" />
+			<!-- Côte d'Ivoire -->
+			<xs:enumeration value="CI" />
+			<!-- Cook Islands -->
+			<xs:enumeration value="CK" />
+			<!-- Chile  -->
+			<xs:enumeration value="CL" />
+			<!-- Cameroon -->
+			<xs:enumeration value="CM" />
+			<!-- China -->
+			<xs:enumeration value="CN" />
+			<!-- Colombia -->
+			<xs:enumeration value="CO" />
+			<!-- Costa Rica -->
+			<xs:enumeration value="CR" />
+			<!-- Cuba -->
+			<xs:enumeration value="CU" />
+			<!-- Cabo Verde -->
+			<xs:enumeration value="CV" />
+			<!-- Curaçao -->
+			<xs:enumeration value="CW" />
+			<!-- Christmas Island -->
+			<xs:enumeration value="CX" />
+			<!-- Cyprus -->
+			<xs:enumeration value="CY" />
+			<!-- Czechia -->
+			<xs:enumeration value="CZ" />
+			<!-- Germany -->
+			<xs:enumeration value="DE" />
+			<!-- Djibouti -->
+			<xs:enumeration value="DJ" />
+			<!-- Denmark -->
+			<xs:enumeration value="DK" />
+			<!-- Dominica -->
+			<xs:enumeration value="DM" />
+			<!-- Dominican Republic -->
+			<xs:enumeration value="DO" />
+			<!-- Algeria -->
+			<xs:enumeration value="DZ" />
+			<!-- Ecuador -->
+			<xs:enumeration value="EC" />
+			<!-- Estonia -->
+			<xs:enumeration value="EE" />
+			<!-- Egypt -->
+			<xs:enumeration value="EG" />
+			<!-- Western Sahara -->
+			<xs:enumeration value="EH" />
+			<!-- Eritrea -->
+			<xs:enumeration value="ER" />
+			<!-- Spain -->
+			<xs:enumeration value="ES" />
+			<!-- Ethiopia -->
+			<xs:enumeration value="ET" />
+			<!-- Finland -->
+			<xs:enumeration value="FI" />
+			<!-- Fiji -->
+			<xs:enumeration value="FJ" />
+			<!-- Falkland Islands (Malvinas) -->
+			<xs:enumeration value="FK" />
+			<!-- Micronesia (Federated States of) -->
+			<xs:enumeration value="FM" />
+			<!-- Faroe Islands -->
+			<xs:enumeration value="FO" />
+			<!-- France -->
+			<xs:enumeration value="FR" />
+			<!-- Gabon -->
+			<xs:enumeration value="GA" />
+			<!-- United Kingdom of Great Britain and Northern Ireland -->
+			<xs:enumeration value="GB" />
+			<!-- Grenada -->
+			<xs:enumeration value="GD" />
+			<!-- Georgia -->
+			<xs:enumeration value="GE" />
+			<!-- French Guiana -->
+			<xs:enumeration value="GF" />
+			<!-- Guernsey (A British Crown Dependency) -->
+			<xs:enumeration value="GG" />
+			<!-- Ghana -->
+			<xs:enumeration value="GH" />
+			<!-- Gibraltar -->
+			<xs:enumeration value="GI" />
+			<!-- Greenland -->
+			<xs:enumeration value="GL" />
+			<!-- Gambia -->
+			<xs:enumeration value="GM" />
+			<!-- Guinea -->
+			<xs:enumeration value="GN" />
+			<!-- Guadeloupe -->
+			<xs:enumeration value="GP" />
+			<!-- Equatorial Guinea -->
+			<xs:enumeration value="GQ" />
+			<!-- Greece -->
+			<xs:enumeration value="GR" />
+			<!-- South Georgia and the South Sandwich Islands -->
+			<xs:enumeration value="GS" />
+			<!-- Guatemala -->
+			<xs:enumeration value="GT" />
+			<!-- Guam -->
+			<xs:enumeration value="GU" />
+			<!-- Guinea-Bissau -->
+			<xs:enumeration value="GW" />
+			<!-- Guyana  -->
+			<xs:enumeration value="GY" />
+			<!-- Hong Kong -->
+			<xs:enumeration value="HK" />
+			<!-- Heard Island and McDonald Islands (External territory of Australia) -->
+			<xs:enumeration value="HM" />
+			<!-- Honduras -->
+			<xs:enumeration value="HN" />
+			<!-- Croatia -->
+			<xs:enumeration value="HR" />
+			<!-- Haiti -->
+			<xs:enumeration value="HT" />
+			<!-- Hungary  -->
+			<xs:enumeration value="HU" />
+			<!-- Indonesia -->
+			<xs:enumeration value="ID" />
+			<!-- Ireland -->
+			<xs:enumeration value="IE" />
+			<!-- Israel -->
+			<xs:enumeration value="IL" />
+			<!-- Isle of Man (A British Crown Dependency) -->
+			<xs:enumeration value="IM" />
+			<!-- India -->
+			<xs:enumeration value="IN" />
+			<!-- British Indian Ocean Territory -->
+			<xs:enumeration value="IO" />
+			<!-- Iraq -->
+			<xs:enumeration value="IQ" />
+			<!-- Iran (Islamic Republic of) -->
+			<xs:enumeration value="IR" />
+			<!-- Iceland -->
+			<xs:enumeration value="IS" />
+			<!-- Italy -->
+			<xs:enumeration value="IT" />
+			<!-- Jersey (A British Crown Dependency) -->
+			<xs:enumeration value="JE" />
+			<!-- Jamaica -->
+			<xs:enumeration value="JM" />
+			<!-- Jordan  -->
+			<xs:enumeration value="JO" />
+			<!-- Japan -->
+			<xs:enumeration value="JP" />
+			<!-- Kenya -->
+			<xs:enumeration value="KE" />
+			<!-- Kyrgyzstan -->
+			<xs:enumeration value="KG" />
+			<!-- Cambodia -->
+			<xs:enumeration value="KH" />
+			<!-- Kiribati -->
+			<xs:enumeration value="KI" />
+			<!-- Comoros -->
+			<xs:enumeration value="KM" />
+			<!-- Saint Kitts and Nevis -->
+			<xs:enumeration value="KN" />
+			<!-- Korea (Democratic People's Republic of) (common name: North Korea) -->
+			<xs:enumeration value="KP" />
+			<!-- Korea, Republic of (common name: South Korea) -->
+			<xs:enumeration value="KR" />
+			<!-- Kuwait -->
+			<xs:enumeration value="KW" />
+			<!-- Cayman Islands -->
+			<xs:enumeration value="KY" />
+			<!-- Kazakhstan -->
+			<xs:enumeration value="KZ" />
+			<!-- Lao People's Democratic Republic -->
+			<xs:enumeration value="LA" />
+			<!-- Lebanon -->
+			<xs:enumeration value="LB" />
+			<!-- Saint Lucia -->
+			<xs:enumeration value="LC" />
+			<!-- Liechtenstein -->
+			<xs:enumeration value="LI" />
+			<!-- Sri Lanka  -->
+			<xs:enumeration value="LK" />
+			<!-- Liberia -->
+			<xs:enumeration value="LR" />
+			<!-- Lesotho -->
+			<xs:enumeration value="LS" />
+			<!-- Lithuania  -->
+			<xs:enumeration value="LT" />
+			<!-- Luxembourg -->
+			<xs:enumeration value="LU" />
+			<!-- Latvia -->
+			<xs:enumeration value="LV" />
+			<!-- Libya -->
+			<xs:enumeration value="LY" />
+			<!-- Morocco -->
+			<xs:enumeration value="MA" />
+			<!-- Monaco -->
+			<xs:enumeration value="MC" />
+			<!-- Moldova, Republic of -->
+			<xs:enumeration value="MD" />
+			<!-- Montenegro -->
+			<xs:enumeration value="ME" />
+			<!-- Saint Martin (French part) -->
+			<xs:enumeration value="MF" />
+			<!-- Madagascar -->
+			<xs:enumeration value="MG" />
+			<!-- Marshall Islands -->
+			<xs:enumeration value="MH" />
+			<!-- North Macedonia -->
+			<xs:enumeration value="MK" />
+			<!-- Mali -->
+			<xs:enumeration value="ML" />
+			<!-- Myanmar -->
+			<xs:enumeration value="MM" />
+			<!-- Mongolia -->
+			<xs:enumeration value="MN" />
+			<!-- Macao -->
+			<xs:enumeration value="MO" />
+			<!-- Northern Mariana Islands -->
+			<xs:enumeration value="MP" />
+			<!-- Martinique -->
+			<xs:enumeration value="MQ" />
+			<!-- Mauritania -->
+			<xs:enumeration value="MR" />
+			<!-- Montserrat -->
+			<xs:enumeration value="MS" />
+			<!-- Malta -->
+			<xs:enumeration value="MT" />
+			<!-- Mauritius -->
+			<xs:enumeration value="MU" />
+			<!-- Maldives -->
+			<xs:enumeration value="MV" />
+			<!-- Malawi -->
+			<xs:enumeration value="MW" />
+			<!-- Mexico -->
+			<xs:enumeration value="MX" />
+			<!-- Malaysia -->
+			<xs:enumeration value="MY" />
+			<!-- Mozambique -->
+			<xs:enumeration value="MZ" />
+			<!-- Namibia -->
+			<xs:enumeration value="NA" />
+			<!-- New Caledonia -->
+			<xs:enumeration value="NC" />
+			<!-- Niger -->
+			<xs:enumeration value="NE" />
+			<!-- Norfolk Island (External territory of Australia) -->
+			<xs:enumeration value="NF" />
+			<!-- Nigeria -->
+			<xs:enumeration value="NG" />
+			<!-- Nicaragua -->
+			<xs:enumeration value="NI" />
+			<!-- Netherlands, Kingdom of the -->
+			<xs:enumeration value="NL" />
+			<!-- Norway -->
+			<xs:enumeration value="NO" />
+			<!-- Nepal -->
+			<xs:enumeration value="NP" />
+			<!-- Nauru -->
+			<xs:enumeration value="NR" />
+			<!-- Niue -->
+			<xs:enumeration value="NU" />
+			<!-- New Zealand -->
+			<xs:enumeration value="NZ" />
+			<!-- Oman -->
+			<xs:enumeration value="OM" />
+			<!-- Panama -->
+			<xs:enumeration value="PA" />
+			<!-- Peru -->
+			<xs:enumeration value="PE" />
+			<!-- French Polynesia -->
+			<xs:enumeration value="PF" />
+			<!-- Papua New Guinea -->
+			<xs:enumeration value="PG" />
+			<!-- Philippines -->
+			<xs:enumeration value="PH" />
+			<!-- Pakistan -->
+			<xs:enumeration value="PK" />
+			<!-- Poland -->
+			<xs:enumeration value="PL" />
+			<!-- Saint Pierre and Miquelon -->
+			<xs:enumeration value="PM" />
+			<!-- Pitcairn -->
+			<xs:enumeration value="PN" />
+			<!-- Puerto Rico -->
+			<xs:enumeration value="PR" />
+			<!-- Palestine, State of -->
+			<xs:enumeration value="PS" />
+			<!-- Portugal -->
+			<xs:enumeration value="PT" />
+			<!-- Palau -->
+			<xs:enumeration value="PW" />
+			<!-- Paraguay -->
+			<xs:enumeration value="PY" />
+			<!-- Qatar -->
+			<xs:enumeration value="QA" />
+			<!-- Réunion -->
+			<xs:enumeration value="RE" />
+			<!-- Romania -->
+			<xs:enumeration value="RO" />
+			<!-- Serbia -->
+			<xs:enumeration value="RS" />
+			<!-- Russian Federation -->
+			<xs:enumeration value="RU" />
+			<!-- Rwanda -->
+			<xs:enumeration value="RW" />
+			<!-- Saudi Arabia -->
+			<xs:enumeration value="SA" />
+			<!-- Solomon Islands -->
+			<xs:enumeration value="SB" />
+			<!-- Seychelles -->
+			<xs:enumeration value="SC" />
+			<!-- Sudan -->
+			<xs:enumeration value="SD" />
+			<!-- Sweden -->
+			<xs:enumeration value="SE" />
+			<!-- Singapore -->
+			<xs:enumeration value="SG" />
+			<!-- Saint Helena, Ascension and Tristan da Cunha -->
+			<xs:enumeration value="SH" />
+			<!-- Slovenia -->
+			<xs:enumeration value="SI" />
+			<!-- Svalbard and Jan Mayen -->
+			<xs:enumeration value="SJ" />
+			<!-- Slovakia -->
+			<xs:enumeration value="SK" />
+			<!-- Sierra Leone -->
+			<xs:enumeration value="SL" />
+			<!-- San Marino -->
+			<xs:enumeration value="SM" />
+			<!-- Senegal -->
+			<xs:enumeration value="SN" />
+			<!-- Somalia -->
+			<xs:enumeration value="SO" />
+			<!-- Suriname -->
+			<xs:enumeration value="SR" />
+			<!-- South Sudan -->
+			<xs:enumeration value="SS" />
+			<!-- Sao Tome and Principe -->
+			<xs:enumeration value="ST" />
+			<!-- El Salvador -->
+			<xs:enumeration value="SV" />
+			<!-- Sint Maarten (Dutch part) -->
+			<xs:enumeration value="SX" />
+			<!-- Syrian Arab Republic -->
+			<xs:enumeration value="SY" />
+			<!-- Eswatini -->
+			<xs:enumeration value="SZ" />
+			<!-- Turks and Caicos Islands -->
+			<xs:enumeration value="TC" />
+			<!-- Chad -->
+			<xs:enumeration value="TD" />
+			<!-- French Southern Territories -->
+			<xs:enumeration value="TF" />
+			<!-- Togo -->
+			<xs:enumeration value="TG" />
+			<!-- Thailand -->
+			<xs:enumeration value="TH" />
+			<!-- Tajikistan -->
+			<xs:enumeration value="TJ" />
+			<!-- Tokelau -->
+			<xs:enumeration value="TK" />
+			<!-- Timor-Leste -->
+			<xs:enumeration value="TL" />
+			<!-- Turkmenistan -->
+			<xs:enumeration value="TM" />
+			<!-- Tunisia -->
+			<xs:enumeration value="TN" />
+			<!-- Tonga -->
+			<xs:enumeration value="TO" />
+			<!-- Türkiye -->
+			<xs:enumeration value="TR" />
+			<!-- Trinidad and Tobago -->
+			<xs:enumeration value="TT" />
+			<!-- Tuvalu -->
+			<xs:enumeration value="TV" />
+			<!-- Taiwan, Province of China -->
+			<xs:enumeration value="TW" />
+			<!-- Tanzania, United Republic of -->
+			<xs:enumeration value="TZ" />
+			<!-- Ukraine -->
+			<xs:enumeration value="UA" />
+			<!-- Uganda -->
+			<xs:enumeration value="UG" />
+			<!-- United States Minor Outlying Islands -->
+			<xs:enumeration value="UM" />
+			<!-- United States of America -->
+			<xs:enumeration value="US" />
+			<!-- Uruguay -->
+			<xs:enumeration value="UY" />
+			<!-- Uzbekistan -->
+			<xs:enumeration value="UZ" />
+			<!-- Holy See -->
+			<xs:enumeration value="VA" />
+			<!-- Saint Vincent and the Grenadines -->
+			<xs:enumeration value="VC" />
+			<!-- Venezuela (Bolivarian Republic of) -->
+			<xs:enumeration value="VE" />
+			<!-- Virgin Islands (British) -->
+			<xs:enumeration value="VG" />
+			<!-- Virgin Islands (U.S.) -->
+			<xs:enumeration value="VI" />
+			<!-- Viet Nam -->
+			<xs:enumeration value="VN" />
+			<!-- Vanuatu -->
+			<xs:enumeration value="VU" />
+			<!-- Wallis and Futuna -->
+			<xs:enumeration value="WF" />
+			<!-- Samoa -->
+			<xs:enumeration value="WS" />
+			<!-- Yemen -->
+			<xs:enumeration value="YE" />
+			<!-- Mayotte -->
+			<xs:enumeration value="YT" />
+			<!-- South Africa -->
+			<xs:enumeration value="ZA" />
+			<!-- Zambia -->
+			<xs:enumeration value="ZM" />
+			<!-- Zimbabwe -->
+			<xs:enumeration value="ZW" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="countryIso3Type" id="countryIso3Type">
+		<xs:annotation>
+			<xs:documentation>Three-letter ISO 3166-1 alpha-3 country code.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ABW" />
+			<!-- Aruba -->
+			<xs:enumeration value="AFG" />
+			<!-- Afghanistan -->
+			<xs:enumeration value="AGO" />
+			<!-- Angola -->
+			<xs:enumeration value="AIA" />
+			<!-- Anguilla -->
+			<xs:enumeration value="ALA" />
+			<!-- Åland Islands -->
+			<xs:enumeration value="ALB" />
+			<!-- Albania -->
+			<xs:enumeration value="AND" />
+			<!-- Andorra -->
+			<xs:enumeration value="ARE" />
+			<!-- United Arab Emirates -->
+			<xs:enumeration value="ARG" />
+			<!-- Argentina -->
+			<xs:enumeration value="ARM" />
+			<!-- Armenia -->
+			<xs:enumeration value="ASM" />
+			<!-- American Samoa -->
+			<xs:enumeration value="ATA" />
+			<!-- Antarctica -->
+			<xs:enumeration value="ATF" />
+			<!-- French Southern Territories -->
+			<xs:enumeration value="ATG" />
+			<!-- Antigua and Barbuda -->
+			<xs:enumeration value="AUS" />
+			<!-- Australia -->
+			<xs:enumeration value="AUT" />
+			<!-- Austria -->
+			<xs:enumeration value="AZE" />
+			<!-- Azerbaijan -->
+			<xs:enumeration value="BDI" />
+			<!-- Burundi -->
+			<xs:enumeration value="BEL" />
+			<!-- Belgium -->
+			<xs:enumeration value="BEN" />
+			<!-- Benin -->
+			<xs:enumeration value="BES" />
+			<!-- Bonaire, Sint Eustatius and Saba -->
+			<xs:enumeration value="BFA" />
+			<!-- Burkina Faso -->
+			<xs:enumeration value="BGD" />
+			<!-- Bangladesh -->
+			<xs:enumeration value="BGR" />
+			<!-- Bulgaria -->
+			<xs:enumeration value="BHR" />
+			<!-- Bahrain -->
+			<xs:enumeration value="BHS" />
+			<!-- Bahamas -->
+			<xs:enumeration value="BIH" />
+			<!-- Bosnia and Herzegovina -->
+			<xs:enumeration value="BLM" />
+			<!-- Saint Barthélemy -->
+			<xs:enumeration value="BLR" />
+			<!-- Belarus -->
+			<xs:enumeration value="BLZ" />
+			<!-- Belize -->
+			<xs:enumeration value="BMU" />
+			<!-- Bermuda -->
+			<xs:enumeration value="BOL" />
+			<!-- Bolivia, Plurinational State of -->
+			<xs:enumeration value="BRA" />
+			<!-- Brazil -->
+			<xs:enumeration value="BRB" />
+			<!-- Barbados -->
+			<xs:enumeration value="BRN" />
+			<!-- Brunei Darussalam -->
+			<xs:enumeration value="BTN" />
+			<!-- Bhutan -->
+			<xs:enumeration value="BVT" />
+			<!-- Bouvet Island -->
+			<xs:enumeration value="BWA" />
+			<!-- Botswana -->
+			<xs:enumeration value="CAF" />
+			<!-- Central African Republic -->
+			<xs:enumeration value="CAN" />
+			<!-- Canada -->
+			<xs:enumeration value="CCK" />
+			<!-- Cocos (Keeling) Islands -->
+			<xs:enumeration value="CHE" />
+			<!-- Switzerland -->
+			<xs:enumeration value="CHL" />
+			<!-- Chile -->
+			<xs:enumeration value="CHN" />
+			<!-- China -->
+			<xs:enumeration value="CIV" />
+			<!-- Côte d'Ivoire -->
+			<xs:enumeration value="CMR" />
+			<!-- Cameroon -->
+			<xs:enumeration value="COD" />
+			<!-- Congo, Democratic Republic of the -->
+			<xs:enumeration value="COG" />
+			<!-- Congo -->
+			<xs:enumeration value="COK" />
+			<!-- Cook Islands -->
+			<xs:enumeration value="COL" />
+			<!-- Colombia -->
+			<xs:enumeration value="COM" />
+			<!-- Comoros -->
+			<xs:enumeration value="CPV" />
+			<!-- Cabo Verde -->
+			<xs:enumeration value="CRI" />
+			<!-- Costa Rica -->
+			<xs:enumeration value="CUB" />
+			<!-- Cuba -->
+			<xs:enumeration value="CUW" />
+			<!-- Curaçao -->
+			<xs:enumeration value="CXR" />
+			<!-- Christmas Island -->
+			<xs:enumeration value="CYM" />
+			<!-- Cayman Islands -->
+			<xs:enumeration value="CYP" />
+			<!-- Cyprus -->
+			<xs:enumeration value="CZE" />
+			<!-- Czechia -->
+			<xs:enumeration value="DEU" />
+			<!-- Germany -->
+			<xs:enumeration value="DJI" />
+			<!-- Djibouti -->
+			<xs:enumeration value="DMA" />
+			<!-- Dominica -->
+			<xs:enumeration value="DNK" />
+			<!-- Denmark -->
+			<xs:enumeration value="DOM" />
+			<!-- Dominican Republic -->
+			<xs:enumeration value="DZA" />
+			<!-- Algeria -->
+			<xs:enumeration value="ECU" />
+			<!-- Ecuador -->
+			<xs:enumeration value="EGY" />
+			<!-- Egypt -->
+			<xs:enumeration value="ERI" />
+			<!-- Eritrea -->
+			<xs:enumeration value="ESH" />
+			<!-- Western Sahara -->
+			<xs:enumeration value="ESP" />
+			<!-- Spain -->
+			<xs:enumeration value="EST" />
+			<!-- Estonia -->
+			<xs:enumeration value="ETH" />
+			<!-- Ethiopia -->
+			<xs:enumeration value="FIN" />
+			<!-- Finland -->
+			<xs:enumeration value="FJI" />
+			<!-- Fiji -->
+			<xs:enumeration value="FLK" />
+			<!-- Falkland Islands (Malvinas) -->
+			<xs:enumeration value="FRA" />
+			<!-- France -->
+			<xs:enumeration value="FRO" />
+			<!-- Faroe Islands -->
+			<xs:enumeration value="FSM" />
+			<!-- Micronesia, Federated States of -->
+			<xs:enumeration value="GAB" />
+			<!-- Gabon -->
+			<xs:enumeration value="GBR" />
+			<!-- United Kingdom of Great Britain and Northern Ireland -->
+			<xs:enumeration value="GEO" />
+			<!-- Georgia -->
+			<xs:enumeration value="GGY" />
+			<!-- Guernsey -->
+			<xs:enumeration value="GHA" />
+			<!-- Ghana -->
+			<xs:enumeration value="GIB" />
+			<!-- Gibraltar -->
+			<xs:enumeration value="GIN" />
+			<!-- Guinea -->
+			<xs:enumeration value="GLP" />
+			<!-- Guadeloupe -->
+			<xs:enumeration value="GMB" />
+			<!-- Gambia -->
+			<xs:enumeration value="GNB" />
+			<!-- Guinea-Bissau -->
+			<xs:enumeration value="GNQ" />
+			<!-- Equatorial Guinea -->
+			<xs:enumeration value="GRC" />
+			<!-- Greece -->
+			<xs:enumeration value="GRD" />
+			<!-- Grenada -->
+			<xs:enumeration value="GRL" />
+			<!-- Greenland -->
+			<xs:enumeration value="GTM" />
+			<!-- Guatemala -->
+			<xs:enumeration value="GUF" />
+			<!-- French Guiana -->
+			<xs:enumeration value="GUM" />
+			<!-- Guam -->
+			<xs:enumeration value="GUY" />
+			<!-- Guyana -->
+			<xs:enumeration value="HKG" />
+			<!-- Hong Kong -->
+			<xs:enumeration value="HMD" />
+			<!-- Heard Island and McDonald Islands -->
+			<xs:enumeration value="HND" />
+			<!-- Honduras -->
+			<xs:enumeration value="HRV" />
+			<!-- Croatia -->
+			<xs:enumeration value="HTI" />
+			<!-- Haiti -->
+			<xs:enumeration value="HUN" />
+			<!-- Hungary -->
+			<xs:enumeration value="IDN" />
+			<!-- Indonesia -->
+			<xs:enumeration value="IMN" />
+			<!-- Isle of Man -->
+			<xs:enumeration value="IND" />
+			<!-- India -->
+			<xs:enumeration value="IOT" />
+			<!-- British Indian Ocean Territory -->
+			<xs:enumeration value="IRL" />
+			<!-- Ireland -->
+			<xs:enumeration value="IRN" />
+			<!-- Iran, Islamic Republic of -->
+			<xs:enumeration value="IRQ" />
+			<!-- Iraq -->
+			<xs:enumeration value="ISL" />
+			<!-- Iceland -->
+			<xs:enumeration value="ISR" />
+			<!-- Israel -->
+			<xs:enumeration value="ITA" />
+			<!-- Italy -->
+			<xs:enumeration value="JAM" />
+			<!-- Jamaica -->
+			<xs:enumeration value="JEY" />
+			<!-- Jersey -->
+			<xs:enumeration value="JOR" />
+			<!-- Jordan -->
+			<xs:enumeration value="JPN" />
+			<!-- Japan -->
+			<xs:enumeration value="KAZ" />
+			<!-- Kazakhstan -->
+			<xs:enumeration value="KEN" />
+			<!-- Kenya -->
+			<xs:enumeration value="KGZ" />
+			<!-- Kyrgyzstan -->
+			<xs:enumeration value="KHM" />
+			<!-- Cambodia -->
+			<xs:enumeration value="KIR" />
+			<!-- Kiribati -->
+			<xs:enumeration value="KNA" />
+			<!-- Saint Kitts and Nevis -->
+			<xs:enumeration value="KOR" />
+			<!-- Korea, Republic of -->
+			<xs:enumeration value="KWT" />
+			<!-- Kuwait -->
+			<xs:enumeration value="LAO" />
+			<!-- Lao People's Democratic Republic -->
+			<xs:enumeration value="LBN" />
+			<!-- Lebanon -->
+			<xs:enumeration value="LBR" />
+			<!-- Liberia -->
+			<xs:enumeration value="LBY" />
+			<!-- Libya -->
+			<xs:enumeration value="LCA" />
+			<!-- Saint Lucia -->
+			<xs:enumeration value="LIE" />
+			<!-- Liechtenstein -->
+			<xs:enumeration value="LKA" />
+			<!-- Sri Lanka -->
+			<xs:enumeration value="LSO" />
+			<!-- Lesotho -->
+			<xs:enumeration value="LTU" />
+			<!-- Lithuania -->
+			<xs:enumeration value="LUX" />
+			<!-- Luxembourg -->
+			<xs:enumeration value="LVA" />
+			<!-- Latvia -->
+			<xs:enumeration value="MAC" />
+			<!-- Macao -->
+			<xs:enumeration value="MAF" />
+			<!-- Saint Martin (French part) -->
+			<xs:enumeration value="MAR" />
+			<!-- Morocco -->
+			<xs:enumeration value="MCO" />
+			<!-- Monaco -->
+			<xs:enumeration value="MDA" />
+			<!-- Moldova, Republic of -->
+			<xs:enumeration value="MDG" />
+			<!-- Madagascar -->
+			<xs:enumeration value="MDV" />
+			<!-- Maldives -->
+			<xs:enumeration value="MEX" />
+			<!-- Mexico -->
+			<xs:enumeration value="MHL" />
+			<!-- Marshall Islands -->
+			<xs:enumeration value="MKD" />
+			<!-- North Macedonia -->
+			<xs:enumeration value="MLI" />
+			<!-- Mali -->
+			<xs:enumeration value="MLT" />
+			<!-- Malta -->
+			<xs:enumeration value="MMR" />
+			<!-- Myanmar -->
+			<xs:enumeration value="MNE" />
+			<!-- Montenegro -->
+			<xs:enumeration value="MNG" />
+			<!-- Mongolia -->
+			<xs:enumeration value="MNP" />
+			<!-- Northern Mariana Islands -->
+			<xs:enumeration value="MOZ" />
+			<!-- Mozambique -->
+			<xs:enumeration value="MRT" />
+			<!-- Mauritania -->
+			<xs:enumeration value="MSR" />
+			<!-- Montserrat -->
+			<xs:enumeration value="MTQ" />
+			<!-- Martinique -->
+			<xs:enumeration value="MUS" />
+			<!-- Mauritius -->
+			<xs:enumeration value="MWI" />
+			<!-- Malawi -->
+			<xs:enumeration value="MYS" />
+			<!-- Malaysia -->
+			<xs:enumeration value="MYT" />
+			<!-- Mayotte -->
+			<xs:enumeration value="NAM" />
+			<!-- Namibia -->
+			<xs:enumeration value="NCL" />
+			<!-- New Caledonia -->
+			<xs:enumeration value="NER" />
+			<!-- Niger -->
+			<xs:enumeration value="NFK" />
+			<!-- Norfolk Island -->
+			<xs:enumeration value="NGA" />
+			<!-- Nigeria -->
+			<xs:enumeration value="NIC" />
+			<!-- Nicaragua -->
+			<xs:enumeration value="NIU" />
+			<!-- Niue -->
+			<xs:enumeration value="NLD" />
+			<!-- Netherlands, Kingdom of the -->
+			<xs:enumeration value="NOR" />
+			<!-- Norway -->
+			<xs:enumeration value="NPL" />
+			<!-- Nepal -->
+			<xs:enumeration value="NRU" />
+			<!-- Nauru -->
+			<xs:enumeration value="NZL" />
+			<!-- New Zealand -->
+			<xs:enumeration value="OMN" />
+			<!-- Oman -->
+			<xs:enumeration value="PAK" />
+			<!-- Pakistan -->
+			<xs:enumeration value="PAN" />
+			<!-- Panama -->
+			<xs:enumeration value="PCN" />
+			<!-- Pitcairn -->
+			<xs:enumeration value="PER" />
+			<!-- Peru -->
+			<xs:enumeration value="PHL" />
+			<!-- Philippines -->
+			<xs:enumeration value="PLW" />
+			<!-- Palau -->
+			<xs:enumeration value="PNG" />
+			<!-- Papua New Guinea -->
+			<xs:enumeration value="POL" />
+			<!-- Poland -->
+			<xs:enumeration value="PRI" />
+			<!-- Puerto Rico -->
+			<xs:enumeration value="PRK" />
+			<!-- Korea, Democratic People's Republic of -->
+			<xs:enumeration value="PRT" />
+			<!-- Portugal -->
+			<xs:enumeration value="PRY" />
+			<!-- Paraguay -->
+			<xs:enumeration value="PSE" />
+			<!-- Palestine, State of -->
+			<xs:enumeration value="PYF" />
+			<!-- French Polynesia -->
+			<xs:enumeration value="QAT" />
+			<!-- Qatar -->
+			<xs:enumeration value="REU" />
+			<!-- Réunion -->
+			<xs:enumeration value="ROU" />
+			<!-- Romania -->
+			<xs:enumeration value="RUS" />
+			<!-- Russian Federation -->
+			<xs:enumeration value="RWA" />
+			<!-- Rwanda -->
+			<xs:enumeration value="SAU" />
+			<!-- Saudi Arabia -->
+			<xs:enumeration value="SDN" />
+			<!-- Sudan -->
+			<xs:enumeration value="SEN" />
+			<!-- Senegal -->
+			<xs:enumeration value="SGP" />
+			<!-- Singapore -->
+			<xs:enumeration value="SGS" />
+			<!-- South Georgia and the South Sandwich Islands -->
+			<xs:enumeration value="SHN" />
+			<!-- Saint Helena, Ascension and Tristan da Cunha -->
+			<xs:enumeration value="SJM" />
+			<!-- Svalbard and Jan Mayen -->
+			<xs:enumeration value="SLB" />
+			<!-- Solomon Islands -->
+			<xs:enumeration value="SLE" />
+			<!-- Sierra Leone -->
+			<xs:enumeration value="SLV" />
+			<!-- El Salvador -->
+			<xs:enumeration value="SMR" />
+			<!-- San Marino -->
+			<xs:enumeration value="SOM" />
+			<!-- Somalia -->
+			<xs:enumeration value="SPM" />
+			<!-- Saint Pierre and Miquelon -->
+			<xs:enumeration value="SRB" />
+			<!-- Serbia -->
+			<xs:enumeration value="SSD" />
+			<!-- South Sudan -->
+			<xs:enumeration value="STP" />
+			<!-- Sao Tome and Principe -->
+			<xs:enumeration value="SUR" />
+			<!-- Suriname -->
+			<xs:enumeration value="SVK" />
+			<!-- Slovakia -->
+			<xs:enumeration value="SVN" />
+			<!-- Slovenia -->
+			<xs:enumeration value="SWE" />
+			<!-- Sweden -->
+			<xs:enumeration value="SWZ" />
+			<!-- Eswatini -->
+			<xs:enumeration value="SXM" />
+			<!-- Sint Maarten (Dutch part) -->
+			<xs:enumeration value="SYC" />
+			<!-- Seychelles -->
+			<xs:enumeration value="SYR" />
+			<!-- Syrian Arab Republic -->
+			<xs:enumeration value="TCA" />
+			<!-- Turks and Caicos Islands -->
+			<xs:enumeration value="TCD" />
+			<!-- Chad -->
+			<xs:enumeration value="TGO" />
+			<!-- Togo -->
+			<xs:enumeration value="THA" />
+			<!-- Thailand -->
+			<xs:enumeration value="TJK" />
+			<!-- Tajikistan -->
+			<xs:enumeration value="TKL" />
+			<!-- Tokelau -->
+			<xs:enumeration value="TKM" />
+			<!-- Turkmenistan -->
+			<xs:enumeration value="TLS" />
+			<!-- Timor-Leste -->
+			<xs:enumeration value="TON" />
+			<!-- Tonga -->
+			<xs:enumeration value="TTO" />
+			<!-- Trinidad and Tobago -->
+			<xs:enumeration value="TUN" />
+			<!-- Tunisia -->
+			<xs:enumeration value="TUR" />
+			<!-- Türkiye -->
+			<xs:enumeration value="TUV" />
+			<!-- Tuvalu -->
+			<xs:enumeration value="TWN" />
+			<!-- Taiwan, Province of China -->
+			<xs:enumeration value="TZA" />
+			<!-- Tanzania, United Republic of -->
+			<xs:enumeration value="UGA" />
+			<!-- Uganda -->
+			<xs:enumeration value="UKR" />
+			<!-- Ukraine -->
+			<xs:enumeration value="UMI" />
+			<!-- United States Minor Outlying Islands -->
+			<xs:enumeration value="URY" />
+			<!-- Uruguay -->
+			<xs:enumeration value="USA" />
+			<!-- United States of America -->
+			<xs:enumeration value="UZB" />
+			<!-- Uzbekistan -->
+			<xs:enumeration value="VAT" />
+			<!-- Holy See -->
+			<xs:enumeration value="VCT" />
+			<!-- Saint Vincent and the Grenadines -->
+			<xs:enumeration value="VEN" />
+			<!-- Venezuela, Bolivarian Republic of -->
+			<xs:enumeration value="VGB" />
+			<!-- Virgin Islands (British) -->
+			<xs:enumeration value="VIR" />
+			<!-- Virgin Islands (U.S.) -->
+			<xs:enumeration value="VNM" />
+			<!-- Viet Nam -->
+			<xs:enumeration value="VUT" />
+			<!-- Vanuatu -->
+			<xs:enumeration value="WLF" />
+			<!-- Wallis and Futuna -->
+			<xs:enumeration value="WSM" />
+			<!-- Samoa -->
+			<xs:enumeration value="YEM" />
+			<!-- Yemen -->
+			<xs:enumeration value="ZAF" />
+			<!-- South Africa -->
+			<xs:enumeration value="ZMB" />
+			<!-- Zambia -->
+			<xs:enumeration value="ZWE" />
+			<!-- Zimbabwe -->
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="languageIso2Type" id="languageIso2Type">
+		<xs:annotation>
+			<xs:documentation>Three-letter ISO 639-2/T language code.</xs:documentation>
+		</xs:annotation>
+		<xs:enumeration value="AAR" />
+		<xs:enumeration value="ABK" />
+		<xs:enumeration value="ACE" />
+		<xs:enumeration value="ACH" />
+		<xs:enumeration value="ADA" />
+		<xs:enumeration value="ADY" />
+		<xs:enumeration value="AFA" />
+		<xs:enumeration value="AFH" />
+		<xs:enumeration value="AFR" />
+		<xs:enumeration value="AIN" />
+		<xs:enumeration value="AKA" />
+		<xs:enumeration value="AKK" />
+		<xs:enumeration value="SQI" />
+		<xs:enumeration value="ALE" />
+		<xs:enumeration value="ALG" />
+		<xs:enumeration value="ALT" />
+		<xs:enumeration value="AMH" />
+		<xs:enumeration value="ANG" />
+		<xs:enumeration value="ANP" />
+		<xs:enumeration value="APA" />
+		<xs:enumeration value="ARA" />
+		<xs:enumeration value="ARC" />
+		<xs:enumeration value="ARG" />
+		<xs:enumeration value="HYE" />
+		<xs:enumeration value="ARN" />
+		<xs:enumeration value="ARP" />
+		<xs:enumeration value="ART" />
+		<xs:enumeration value="ARW" />
+		<xs:enumeration value="ASM" />
+		<xs:enumeration value="AST" />
+		<xs:enumeration value="ATH" />
+		<xs:enumeration value="AUS" />
+		<xs:enumeration value="AVA" />
+		<xs:enumeration value="AVE" />
+		<xs:enumeration value="AWA" />
+		<xs:enumeration value="AYM" />
+		<xs:enumeration value="AZE" />
+		<xs:enumeration value="BAD" />
+		<xs:enumeration value="BAI" />
+		<xs:enumeration value="BAK" />
+		<xs:enumeration value="BAL" />
+		<xs:enumeration value="BAM" />
+		<xs:enumeration value="BAN" />
+		<xs:enumeration value="EUS" />
+		<xs:enumeration value="BAS" />
+		<xs:enumeration value="BAT" />
+		<xs:enumeration value="BEJ" />
+		<xs:enumeration value="BEL" />
+		<xs:enumeration value="BEM" />
+		<xs:enumeration value="BEN" />
+		<xs:enumeration value="BER" />
+		<xs:enumeration value="BHO" />
+		<xs:enumeration value="BIH" />
+		<xs:enumeration value="BIK" />
+		<xs:enumeration value="BIN" />
+		<xs:enumeration value="BIS" />
+		<xs:enumeration value="BLA" />
+		<xs:enumeration value="BNT" />
+		<xs:enumeration value="BOS" />
+		<xs:enumeration value="BRA" />
+		<xs:enumeration value="BRE" />
+		<xs:enumeration value="BTK" />
+		<xs:enumeration value="BUA" />
+		<xs:enumeration value="BUG" />
+		<xs:enumeration value="BUL" />
+		<xs:enumeration value="MYA" />
+		<xs:enumeration value="BYN" />
+		<xs:enumeration value="CAD" />
+		<xs:enumeration value="CAI" />
+		<xs:enumeration value="CAR" />
+		<xs:enumeration value="CAT" />
+		<xs:enumeration value="CAU" />
+		<xs:enumeration value="CEB" />
+		<xs:enumeration value="CEL" />
+		<xs:enumeration value="CHA" />
+		<xs:enumeration value="CHB" />
+		<xs:enumeration value="CHE" />
+		<xs:enumeration value="CHG" />
+		<xs:enumeration value="ZHO" />
+		<xs:enumeration value="CHK" />
+		<xs:enumeration value="CHM" />
+		<xs:enumeration value="CHN" />
+		<xs:enumeration value="CHO" />
+		<xs:enumeration value="CHP" />
+		<xs:enumeration value="CHR" />
+		<xs:enumeration value="CHU" />
+		<xs:enumeration value="CHV" />
+		<xs:enumeration value="CHY" />
+		<xs:enumeration value="CMC" />
+		<xs:enumeration value="COP" />
+		<xs:enumeration value="COR" />
+		<xs:enumeration value="COS" />
+		<xs:enumeration value="CPE" />
+		<xs:enumeration value="CPF" />
+		<xs:enumeration value="CPP" />
+		<xs:enumeration value="CRE" />
+		<xs:enumeration value="CRH" />
+		<xs:enumeration value="CRP" />
+		<xs:enumeration value="CSB" />
+		<xs:enumeration value="CUS" />
+		<xs:enumeration value="CES" />
+		<xs:enumeration value="DAK" />
+		<xs:enumeration value="DAN" />
+		<xs:enumeration value="DAR" />
+		<xs:enumeration value="DAY" />
+		<xs:enumeration value="DEL" />
+		<xs:enumeration value="DEN" />
+		<xs:enumeration value="DGR" />
+		<xs:enumeration value="DIN" />
+		<xs:enumeration value="DIV" />
+		<xs:enumeration value="DOI" />
+		<xs:enumeration value="DRA" />
+		<xs:enumeration value="DSB" />
+		<xs:enumeration value="DUA" />
+		<xs:enumeration value="DUM" />
+		<xs:enumeration value="NLD" />
+		<xs:enumeration value="DYU" />
+		<xs:enumeration value="DZO" />
+		<xs:enumeration value="EFI" />
+		<xs:enumeration value="EGY" />
+		<xs:enumeration value="EKA" />
+		<xs:enumeration value="ELX" />
+		<xs:enumeration value="ENG" />
+		<xs:enumeration value="ENM" />
+		<xs:enumeration value="EPO" />
+		<xs:enumeration value="EST" />
+		<xs:enumeration value="EWE" />
+		<xs:enumeration value="EWO" />
+		<xs:enumeration value="FAN" />
+		<xs:enumeration value="FAO" />
+		<xs:enumeration value="FAT" />
+		<xs:enumeration value="FIJ" />
+		<xs:enumeration value="FIL" />
+		<xs:enumeration value="FIN" />
+		<xs:enumeration value="FIU" />
+		<xs:enumeration value="FON" />
+		<xs:enumeration value="FRA" />
+		<xs:enumeration value="FRM" />
+		<xs:enumeration value="FRO" />
+		<xs:enumeration value="FRR" />
+		<xs:enumeration value="FRS" />
+		<xs:enumeration value="FRY" />
+		<xs:enumeration value="FUL" />
+		<xs:enumeration value="FUR" />
+		<xs:enumeration value="GAA" />
+		<xs:enumeration value="GAY" />
+		<xs:enumeration value="GBA" />
+		<xs:enumeration value="GEM" />
+		<xs:enumeration value="KAT" />
+		<xs:enumeration value="DEU" />
+		<xs:enumeration value="GEZ" />
+		<xs:enumeration value="GIL" />
+		<xs:enumeration value="GLA" />
+		<xs:enumeration value="GLE" />
+		<xs:enumeration value="GLG" />
+		<xs:enumeration value="GLV" />
+		<xs:enumeration value="GMH" />
+		<xs:enumeration value="GOH" />
+		<xs:enumeration value="GON" />
+		<xs:enumeration value="GOR" />
+		<xs:enumeration value="GOT" />
+		<xs:enumeration value="GRB" />
+		<xs:enumeration value="GRC" />
+		<xs:enumeration value="ELL" />
+		<xs:enumeration value="GRN" />
+		<xs:enumeration value="GSW" />
+		<xs:enumeration value="GUJ" />
+		<xs:enumeration value="GWI" />
+		<xs:enumeration value="HAI" />
+		<xs:enumeration value="HAT" />
+		<xs:enumeration value="HAU" />
+		<xs:enumeration value="HAW" />
+		<xs:enumeration value="HEB" />
+		<xs:enumeration value="HER" />
+		<xs:enumeration value="HIL" />
+		<xs:enumeration value="HIM" />
+		<xs:enumeration value="HIN" />
+		<xs:enumeration value="HIT" />
+		<xs:enumeration value="HMN" />
+		<xs:enumeration value="HMO" />
+		<xs:enumeration value="HRV" />
+		<xs:enumeration value="HSB" />
+		<xs:enumeration value="HUN" />
+		<xs:enumeration value="HUP" />
+		<xs:enumeration value="IBA" />
+		<xs:enumeration value="IBO" />
+		<xs:enumeration value="ISL" />
+		<xs:enumeration value="IDO" />
+		<xs:enumeration value="III" />
+		<xs:enumeration value="IJO" />
+		<xs:enumeration value="IKU" />
+		<xs:enumeration value="ILE" />
+		<xs:enumeration value="ILO" />
+		<xs:enumeration value="INA" />
+		<xs:enumeration value="INC" />
+		<xs:enumeration value="IND" />
+		<xs:enumeration value="INE" />
+		<xs:enumeration value="INH" />
+		<xs:enumeration value="IPK" />
+		<xs:enumeration value="IRA" />
+		<xs:enumeration value="IRO" />
+		<xs:enumeration value="ITA" />
+		<xs:enumeration value="JAV" />
+		<xs:enumeration value="JBO" />
+		<xs:enumeration value="JPN" />
+		<xs:enumeration value="JPR" />
+		<xs:enumeration value="JRB" />
+		<xs:enumeration value="KAA" />
+		<xs:enumeration value="KAB" />
+		<xs:enumeration value="KAC" />
+		<xs:enumeration value="KAL" />
+		<xs:enumeration value="KAM" />
+		<xs:enumeration value="KAN" />
+		<xs:enumeration value="KAR" />
+		<xs:enumeration value="KAS" />
+		<xs:enumeration value="KAU" />
+		<xs:enumeration value="KAW" />
+		<xs:enumeration value="KAZ" />
+		<xs:enumeration value="KBD" />
+		<xs:enumeration value="KHA" />
+		<xs:enumeration value="KHI" />
+		<xs:enumeration value="KHM" />
+		<xs:enumeration value="KHO" />
+		<xs:enumeration value="KIK" />
+		<xs:enumeration value="KIN" />
+		<xs:enumeration value="KIR" />
+		<xs:enumeration value="KMB" />
+		<xs:enumeration value="KOK" />
+		<xs:enumeration value="KOM" />
+		<xs:enumeration value="KON" />
+		<xs:enumeration value="KOR" />
+		<xs:enumeration value="KOS" />
+		<xs:enumeration value="KPE" />
+		<xs:enumeration value="KRC" />
+		<xs:enumeration value="KRL" />
+		<xs:enumeration value="KRO" />
+		<xs:enumeration value="KRU" />
+		<xs:enumeration value="KUA" />
+		<xs:enumeration value="KUM" />
+		<xs:enumeration value="KUR" />
+		<xs:enumeration value="KUT" />
+		<xs:enumeration value="LAD" />
+		<xs:enumeration value="LAH" />
+		<xs:enumeration value="LAM" />
+		<xs:enumeration value="LAO" />
+		<xs:enumeration value="LAT" />
+		<xs:enumeration value="LAV" />
+		<xs:enumeration value="LEZ" />
+		<xs:enumeration value="LIM" />
+		<xs:enumeration value="LIN" />
+		<xs:enumeration value="LIT" />
+		<xs:enumeration value="LOL" />
+		<xs:enumeration value="LOZ" />
+		<xs:enumeration value="LTZ" />
+		<xs:enumeration value="LUA" />
+		<xs:enumeration value="LUB" />
+		<xs:enumeration value="LUG" />
+		<xs:enumeration value="LUI" />
+		<xs:enumeration value="LUN" />
+		<xs:enumeration value="LUO" />
+		<xs:enumeration value="LUS" />
+		<xs:enumeration value="MKD" />
+		<xs:enumeration value="MAD" />
+		<xs:enumeration value="MAG" />
+		<xs:enumeration value="MAH" />
+		<xs:enumeration value="MAI" />
+		<xs:enumeration value="MAK" />
+		<xs:enumeration value="MAL" />
+		<xs:enumeration value="MAN" />
+		<xs:enumeration value="MRI" />
+		<xs:enumeration value="MAP" />
+		<xs:enumeration value="MAR" />
+		<xs:enumeration value="MAS" />
+		<xs:enumeration value="MSA" />
+		<xs:enumeration value="MDF" />
+		<xs:enumeration value="MDR" />
+		<xs:enumeration value="MEN" />
+		<xs:enumeration value="MGA" />
+		<xs:enumeration value="MIC" />
+		<xs:enumeration value="MIN" />
+		<xs:enumeration value="MKH" />
+		<xs:enumeration value="MLG" />
+		<xs:enumeration value="MLT" />
+		<xs:enumeration value="MNC" />
+		<xs:enumeration value="MNI" />
+		<xs:enumeration value="MNO" />
+		<xs:enumeration value="MOH" />
+		<xs:enumeration value="MON" />
+		<xs:enumeration value="MOS" />
+		<xs:enumeration value="MUN" />
+		<xs:enumeration value="MUS" />
+		<xs:enumeration value="MWL" />
+		<xs:enumeration value="MWR" />
+		<xs:enumeration value="MYN" />
+		<xs:enumeration value="MYV" />
+		<xs:enumeration value="NAH" />
+		<xs:enumeration value="NAI" />
+		<xs:enumeration value="NAP" />
+		<xs:enumeration value="NAU" />
+		<xs:enumeration value="NAV" />
+		<xs:enumeration value="NBL" />
+		<xs:enumeration value="NDE" />
+		<xs:enumeration value="NDO" />
+		<xs:enumeration value="NDS" />
+		<xs:enumeration value="NEP" />
+		<xs:enumeration value="NEW" />
+		<xs:enumeration value="NIA" />
+		<xs:enumeration value="NIC" />
+		<xs:enumeration value="NIU" />
+		<xs:enumeration value="NNO" />
+		<xs:enumeration value="NOB" />
+		<xs:enumeration value="NOG" />
+		<xs:enumeration value="NON" />
+		<xs:enumeration value="NOR" />
+		<xs:enumeration value="NQO" />
+		<xs:enumeration value="NSO" />
+		<xs:enumeration value="NUB" />
+		<xs:enumeration value="NWC" />
+		<xs:enumeration value="NYA" />
+		<xs:enumeration value="NYM" />
+		<xs:enumeration value="NYN" />
+		<xs:enumeration value="NYO" />
+		<xs:enumeration value="NZI" />
+		<xs:enumeration value="OCI" />
+		<xs:enumeration value="OJI" />
+		<xs:enumeration value="ORI" />
+		<xs:enumeration value="ORM" />
+		<xs:enumeration value="OSA" />
+		<xs:enumeration value="OSS" />
+		<xs:enumeration value="OTA" />
+		<xs:enumeration value="OTO" />
+		<xs:enumeration value="PAA" />
+		<xs:enumeration value="PAG" />
+		<xs:enumeration value="PAL" />
+		<xs:enumeration value="PAM" />
+		<xs:enumeration value="PAN" />
+		<xs:enumeration value="PAP" />
+		<xs:enumeration value="PAU" />
+		<xs:enumeration value="PEO" />
+		<xs:enumeration value="FAS" />
+		<xs:enumeration value="PHI" />
+		<xs:enumeration value="PHN" />
+		<xs:enumeration value="PLI" />
+		<xs:enumeration value="POL" />
+		<xs:enumeration value="PON" />
+		<xs:enumeration value="POR" />
+		<xs:enumeration value="PRA" />
+		<xs:enumeration value="PRO" />
+		<xs:enumeration value="PUS" />
+		<xs:enumeration value="QUE" />
+		<xs:enumeration value="RAJ" />
+		<xs:enumeration value="RAP" />
+		<xs:enumeration value="RAR" />
+		<xs:enumeration value="ROA" />
+		<xs:enumeration value="ROH" />
+		<xs:enumeration value="ROM" />
+		<xs:enumeration value="RON" />
+		<xs:enumeration value="RUN" />
+		<xs:enumeration value="RUP" />
+		<xs:enumeration value="RUS" />
+		<xs:enumeration value="SAD" />
+		<xs:enumeration value="SAG" />
+		<xs:enumeration value="SAH" />
+		<xs:enumeration value="SAI" />
+		<xs:enumeration value="SAL" />
+		<xs:enumeration value="SAM" />
+		<xs:enumeration value="SAN" />
+		<xs:enumeration value="SAS" />
+		<xs:enumeration value="SAT" />
+		<xs:enumeration value="SCN" />
+		<xs:enumeration value="SCO" />
+		<xs:enumeration value="SEL" />
+		<xs:enumeration value="SEM" />
+		<xs:enumeration value="SGA" />
+		<xs:enumeration value="SGN" />
+		<xs:enumeration value="SHN" />
+		<xs:enumeration value="SID" />
+		<xs:enumeration value="SIN" />
+		<xs:enumeration value="SIO" />
+		<xs:enumeration value="SIT" />
+		<xs:enumeration value="SLA" />
+		<xs:enumeration value="SLK" />
+		<xs:enumeration value="SLV" />
+		<xs:enumeration value="SMA" />
+		<xs:enumeration value="SME" />
+		<xs:enumeration value="SMI" />
+		<xs:enumeration value="SMJ" />
+		<xs:enumeration value="SMN" />
+		<xs:enumeration value="SMO" />
+		<xs:enumeration value="SMS" />
+		<xs:enumeration value="SNA" />
+		<xs:enumeration value="SND" />
+		<xs:enumeration value="SNK" />
+		<xs:enumeration value="SOG" />
+		<xs:enumeration value="SOM" />
+		<xs:enumeration value="SON" />
+		<xs:enumeration value="SOT" />
+		<xs:enumeration value="SPA" />
+		<xs:enumeration value="SRD" />
+		<xs:enumeration value="SRN" />
+		<xs:enumeration value="SRP" />
+		<xs:enumeration value="SRR" />
+		<xs:enumeration value="SSA" />
+		<xs:enumeration value="SSW" />
+		<xs:enumeration value="SUK" />
+		<xs:enumeration value="SUN" />
+		<xs:enumeration value="SUS" />
+		<xs:enumeration value="SUX" />
+		<xs:enumeration value="SWA" />
+		<xs:enumeration value="SWE" />
+		<xs:enumeration value="SYC" />
+		<xs:enumeration value="SYR" />
+		<xs:enumeration value="TAH" />
+		<xs:enumeration value="TAI" />
+		<xs:enumeration value="TAM" />
+		<xs:enumeration value="TAT" />
+		<xs:enumeration value="TEL" />
+		<xs:enumeration value="TEM" />
+		<xs:enumeration value="TER" />
+		<xs:enumeration value="TET" />
+		<xs:enumeration value="TGK" />
+		<xs:enumeration value="TGL" />
+		<xs:enumeration value="THA" />
+		<xs:enumeration value="BOD" />
+		<xs:enumeration value="TIG" />
+		<xs:enumeration value="TIR" />
+		<xs:enumeration value="TIV" />
+		<xs:enumeration value="TKL" />
+		<xs:enumeration value="TLH" />
+		<xs:enumeration value="TLI" />
+		<xs:enumeration value="TMH" />
+		<xs:enumeration value="TOG" />
+		<xs:enumeration value="TON" />
+		<xs:enumeration value="TPI" />
+		<xs:enumeration value="TSI" />
+		<xs:enumeration value="TSN" />
+		<xs:enumeration value="TSO" />
+		<xs:enumeration value="TUK" />
+		<xs:enumeration value="TUM" />
+		<xs:enumeration value="TUP" />
+		<xs:enumeration value="TUR" />
+		<xs:enumeration value="TUT" />
+		<xs:enumeration value="TVL" />
+		<xs:enumeration value="TWI" />
+		<xs:enumeration value="TYV" />
+		<xs:enumeration value="UDM" />
+		<xs:enumeration value="UGA" />
+		<xs:enumeration value="UIG" />
+		<xs:enumeration value="UKR" />
+		<xs:enumeration value="UMB" />
+		<xs:enumeration value="URD" />
+		<xs:enumeration value="UZB" />
+		<xs:enumeration value="VAI" />
+		<xs:enumeration value="VEN" />
+		<xs:enumeration value="VIE" />
+		<xs:enumeration value="VOL" />
+		<xs:enumeration value="VOT" />
+		<xs:enumeration value="WAK" />
+		<xs:enumeration value="WAL" />
+		<xs:enumeration value="WAR" />
+		<xs:enumeration value="WAS" />
+		<xs:enumeration value="CYM" />
+		<xs:enumeration value="WEN" />
+		<xs:enumeration value="WLN" />
+		<xs:enumeration value="WOL" />
+		<xs:enumeration value="XAL" />
+		<xs:enumeration value="XHO" />
+		<xs:enumeration value="YAO" />
+		<xs:enumeration value="YAP" />
+		<xs:enumeration value="YID" />
+		<xs:enumeration value="YOR" />
+		<xs:enumeration value="YPK" />
+		<xs:enumeration value="ZAP" />
+		<xs:enumeration value="ZBL" />
+		<xs:enumeration value="ZEN" />
+		<xs:enumeration value="ZHA" />
+		<xs:enumeration value="ZND" />
+		<xs:enumeration value="ZUL" />
+		<xs:enumeration value="ZUN" />
+		<xs:enumeration value="ZZA" />
+		<xs:enumeration value="MIS" />
+		<xs:enumeration value="MUL" />
+		<xs:enumeration value="UND" />
+		<xs:enumeration value="ZXX" />
+	</xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="languageIso1Type" id="languageIso1Type">
+	<xs:annotation>
+		<xs:documentation>Two-letter ISO 639-1 language code.</xs:documentation>
+	</xs:annotation>
+	<xs:enumeration value="AB" />
+	<xs:enumeration value="AA" />
+	<xs:enumeration value="AF" />
+	<xs:enumeration value="AK" />
+	<xs:enumeration value="SQ" />
+	<xs:enumeration value="AM" />
+	<xs:enumeration value="AR" />
+	<xs:enumeration value="AN" />
+	<xs:enumeration value="HY" />
+	<xs:enumeration value="AS" />
+	<xs:enumeration value="AV" />
+	<xs:enumeration value="AE" />
+	<xs:enumeration value="AY" />
+	<xs:enumeration value="AZ" />
+	<xs:enumeration value="BM" />
+	<xs:enumeration value="BA" />
+	<xs:enumeration value="EU" />
+	<xs:enumeration value="BE" />
+	<xs:enumeration value="BN" />
+	<xs:enumeration value="BI" />
+	<xs:enumeration value="BS" />
+	<xs:enumeration value="BR" />
+	<xs:enumeration value="BG" />
+	<xs:enumeration value="MY" />
+	<xs:enumeration value="CA" />
+	<xs:enumeration value="CH" />
+	<xs:enumeration value="CE" />
+	<xs:enumeration value="NY" />
+	<xs:enumeration value="ZH" />
+	<xs:enumeration value="CU" />
+	<xs:enumeration value="CV" />
+	<xs:enumeration value="KW" />
+	<xs:enumeration value="CO" />
+	<xs:enumeration value="CR" />
+	<xs:enumeration value="HR" />
+	<xs:enumeration value="CS" />
+	<xs:enumeration value="DA" />
+	<xs:enumeration value="DV" />
+	<xs:enumeration value="NL" />
+	<xs:enumeration value="DZ" />
+	<xs:enumeration value="EN" />
+	<xs:enumeration value="EO" />
+	<xs:enumeration value="ET" />
+	<xs:enumeration value="EE" />
+	<xs:enumeration value="FO" />
+	<xs:enumeration value="FJ" />
+	<xs:enumeration value="FI" />
+	<xs:enumeration value="FR" />
+	<xs:enumeration value="FY" />
+	<xs:enumeration value="FF" />
+	<xs:enumeration value="GD" />
+	<xs:enumeration value="GL" />
+	<xs:enumeration value="LG" />
+	<xs:enumeration value="KA" />
+	<xs:enumeration value="DE" />
+	<xs:enumeration value="EL" />
+	<xs:enumeration value="KL" />
+	<xs:enumeration value="GN" />
+	<xs:enumeration value="GU" />
+	<xs:enumeration value="HT" />
+	<xs:enumeration value="HA" />
+	<xs:enumeration value="HE" />
+	<xs:enumeration value="HZ" />
+	<xs:enumeration value="HI" />
+	<xs:enumeration value="HO" />
+	<xs:enumeration value="HU" />
+	<xs:enumeration value="IS" />
+	<xs:enumeration value="IO" />
+	<xs:enumeration value="IG" />
+	<xs:enumeration value="ID" />
+	<xs:enumeration value="IA" />
+	<xs:enumeration value="IE" />
+	<xs:enumeration value="IU" />
+	<xs:enumeration value="IK" />
+	<xs:enumeration value="GA" />
+	<xs:enumeration value="IT" />
+	<xs:enumeration value="JA" />
+	<xs:enumeration value="JV" />
+	<xs:enumeration value="KN" />
+	<xs:enumeration value="KR" />
+	<xs:enumeration value="KS" />
+	<xs:enumeration value="KK" />
+	<xs:enumeration value="KM" />
+	<xs:enumeration value="KI" />
+	<xs:enumeration value="RW" />
+	<xs:enumeration value="KY" />
+	<xs:enumeration value="KV" />
+	<xs:enumeration value="KG" />
+	<xs:enumeration value="KO" />
+	<xs:enumeration value="KJ" />
+	<xs:enumeration value="KU" />
+	<xs:enumeration value="LO" />
+	<xs:enumeration value="LA" />
+	<xs:enumeration value="LV" />
+	<xs:enumeration value="LI" />
+	<xs:enumeration value="LN" />
+	<xs:enumeration value="LT" />
+	<xs:enumeration value="LU" />
+	<xs:enumeration value="LB" />
+	<xs:enumeration value="MK" />
+	<xs:enumeration value="MG" />
+	<xs:enumeration value="MS" />
+	<xs:enumeration value="ML" />
+	<xs:enumeration value="MT" />
+	<xs:enumeration value="GV" />
+	<xs:enumeration value="MI" />
+	<xs:enumeration value="MR" />
+	<xs:enumeration value="MH" />
+	<xs:enumeration value="MN" />
+	<xs:enumeration value="NA" />
+	<xs:enumeration value="NV" />
+	<xs:enumeration value="ND" />
+	<xs:enumeration value="NR" />
+	<xs:enumeration value="NG" />
+	<xs:enumeration value="NE" />
+	<xs:enumeration value="NO" />
+	<xs:enumeration value="NB" />
+	<xs:enumeration value="NN" />
+	<xs:enumeration value="II" />
+	<xs:enumeration value="OC" />
+	<xs:enumeration value="OJ" />
+	<xs:enumeration value="OR" />
+	<xs:enumeration value="OM" />
+	<xs:enumeration value="OS" />
+	<xs:enumeration value="PI" />
+	<xs:enumeration value="PS" />
+	<xs:enumeration value="FA" />
+	<xs:enumeration value="PL" />
+	<xs:enumeration value="PT" />
+	<xs:enumeration value="PA" />
+	<xs:enumeration value="QU" />
+	<xs:enumeration value="RO" />
+	<xs:enumeration value="RM" />
+	<xs:enumeration value="RN" />
+	<xs:enumeration value="RU" />
+	<xs:enumeration value="SE" />
+	<xs:enumeration value="SM" />
+	<xs:enumeration value="SG" />
+	<xs:enumeration value="SA" />
+	<xs:enumeration value="SC" />
+	<xs:enumeration value="SR" />
+	<xs:enumeration value="SN" />
+	<xs:enumeration value="SD" />
+	<xs:enumeration value="SI" />
+	<xs:enumeration value="SK" />
+	<xs:enumeration value="SL" />
+	<xs:enumeration value="SO" />
+	<xs:enumeration value="ST" />
+	<xs:enumeration value="ES" />
+	<xs:enumeration value="SU" />
+	<xs:enumeration value="SW" />
+	<xs:enumeration value="SS" />
+	<xs:enumeration value="SV" />
+	<xs:enumeration value="TL" />
+	<xs:enumeration value="TY" />
+	<xs:enumeration value="TG" />
+	<xs:enumeration value="TA" />
+	<xs:enumeration value="TT" />
+	<xs:enumeration value="TE" />
+	<xs:enumeration value="TH" />
+	<xs:enumeration value="BO" />
+	<xs:enumeration value="TI" />
+	<xs:enumeration value="TO" />
+	<xs:enumeration value="TS" />
+	<xs:enumeration value="TN" />
+	<xs:enumeration value="TR" />
+	<xs:enumeration value="TK" />
+	<xs:enumeration value="TW" />
+	<xs:enumeration value="UG" />
+	<xs:enumeration value="UK" />
+	<xs:enumeration value="UR" />
+	<xs:enumeration value="UZ" />
+	<xs:enumeration value="VE" />
+	<xs:enumeration value="VI" />
+	<xs:enumeration value="VO" />
+	<xs:enumeration value="WA" />
+	<xs:enumeration value="CY" />
+	<xs:enumeration value="WO" />
+	<xs:enumeration value="XH" />
+	<xs:enumeration value="YI" />
+	<xs:enumeration value="YO" />
+	<xs:enumeration value="ZA" />
+	<xs:enumeration value="ZU" />
+</xs:restriction>
+</xs:simpleType>
+</xs:schema>
+

--- a/jmef.xsd
+++ b/jmef.xsd
@@ -1,1839 +1,1606 @@
-i<?xml version="1.0" encoding="utf-8"?>
-<xs:schema
-	xmlns:xlink="http://www.w3.org/1999/xlink" attributeFormDefault="unqualified" elementFormDefault="qualified"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema">
-	<xs:import schemaLocation="https://www.w3.org/1999/xlink.xsd" namespace="http://www.w3.org/1999/xlink" />
-	<xs:element name="journal">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element maxOccurs="unbounded" name="journal-id">
-					<xs:complexType>
-						<xs:simpleContent>
-							<xs:extension base="xs:string">
-								<xs:attribute name="journal-id-type" type="xs:string" use="required" />
-							</xs:extension>
-						</xs:simpleContent>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="journal-title-group">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="journal-title" type="xs:string" />
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-				<xs:element maxOccurs="unbounded" name="issn">
-					<xs:complexType>
-						<xs:simpleContent>
-							<xs:extension base="xs:string">
-								<xs:attribute name="publication-format" type="xs:string" use="required" />
-							</xs:extension>
-						</xs:simpleContent>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="publisher">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="publisher-name" type="xs:string" />
-							<xs:element name="publisher-location">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="country">
-											<xs:complexType>
-												<xs:simpleContent>
-													<xs:extension base="xs:string">
-														<xs:attribute name="iso2" type="countryIso2Type" use="optional" />
-														<xs:attribute name="iso3" type="xs:string" use="optional" />
-													</xs:extension>
-												</xs:simpleContent>
-											</xs:complexType>
-										</xs:element>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="publication-policy">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="costs">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="apc">
-											<xs:complexType>
-												<xs:attribute name="present" type="xs:boolean" use="required" />
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="other-charges">
-											<xs:complexType>
-												<xs:attribute name="present" type="xs:boolean" use="required" />
-											</xs:complexType>
-										</xs:element>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="review-process">
-								<xs:complexType>
-									<xs:attribute name="peer-review" type="xs:boolean" use="required" />
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="languages">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element maxOccurs="unbounded" name="language">
-											<xs:complexType>
-												<xs:simpleContent>
-													<xs:extension base="xs:string">
-														<xs:attribute name="iso1" type="languageIso1Type" use="optional" />
-														<xs:attribute name="iso2" type="languageIso2Type" use="optional" />
-													</xs:extension>
-												</xs:simpleContent>
-											</xs:complexType>
-										</xs:element>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="licenses">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element maxOccurs="unbounded" name="license">
-											<xs:complexType>
-												<xs:attribute ref="xlink:href" use="required" />
-											</xs:complexType>
-										</xs:element>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="authorship">
-								<xs:complexType>
-									<xs:attribute name="open" type="xs:boolean" use="required" />
-								</xs:complexType>
-							</xs:element>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="self-uri">
-					<xs:complexType>
-						<xs:attribute ref="xlink:href" use="required" />
-					</xs:complexType>
-				</xs:element>
-				<xs:element maxOccurs="unbounded" name="kwd-group">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element minOccurs="0" name="compound-kwd">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element maxOccurs="unbounded" name="compound-kwd-part">
-											<xs:complexType>
-												<xs:simpleContent>
-													<xs:extension base="xs:string">
-														<xs:attribute name="content-type" type="xs:string" use="required" />
-													</xs:extension>
-												</xs:simpleContent>
-											</xs:complexType>
-										</xs:element>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
-							<xs:element minOccurs="0" maxOccurs="unbounded" name="kwd" type="xs:string" />
-						</xs:sequence>
-						<xs:attribute name="vocab" type="xs:string" use="optional" />
-						<xs:attribute name="vocab-identifier" type="xs:string" use="optional" />
-					</xs:complexType>
-				</xs:element>
-			</xs:sequence>
-			<xs:attribute name="owner-type" type="xs:string" use="optional" />
-		</xs:complexType>
-	</xs:element>
-	<xs:simpleType name="countryIso2Type" id="countryIso2Type">
-		<xs:annotation>
-			<xs:documentation>Two-letter ISO 3166-1 alpha-2 country code.</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<!-- Andorra -->
-			<xs:enumeration value="AD" />
-			<!-- United Arab Emirates -->
-			<xs:enumeration value="AE" />
-			<!-- Afghanistan -->
-			<xs:enumeration value="AF" />
-			<!-- Antigua and Barbuda -->
-			<xs:enumeration value="AG" />
-			<!-- Anguilla -->
-			<xs:enumeration value="AI" />
-			<!-- Albania -->
-			<xs:enumeration value="AL" />
-			<!-- Armenia -->
-			<xs:enumeration value="AM" />
-			<!-- Angola -->
-			<xs:enumeration value="AO" />
-			<!-- Antarctica -->
-			<xs:enumeration value="AQ" />
-			<!-- Argentina -->
-			<xs:enumeration value="AR" />
-			<!-- American Samoa -->
-			<xs:enumeration value="AS" />
-			<!-- Austria -->
-			<xs:enumeration value="AT" />
-			<!-- Australia -->
-			<xs:enumeration value="AU" />
-			<!-- Aruba -->
-			<xs:enumeration value="AW" />
-			<!-- Åland Islands (An autonomous county of Finland) -->
-			<xs:enumeration value="AX" />
-			<!-- Azerbaijan -->
-			<xs:enumeration value="AZ" />
-			<!-- Bosnia and Herzegovina -->
-			<xs:enumeration value="BA" />
-			<!-- Barbados -->
-			<xs:enumeration value="BB" />
-			<!-- Bangladesh -->
-			<xs:enumeration value="BD" />
-			<!-- Belgium -->
-			<xs:enumeration value="BE" />
-			<!-- Burkina Faso -->
-			<xs:enumeration value="BF" />
-			<!-- Bulgaria -->
-			<xs:enumeration value="BG" />
-			<!-- Bahrain -->
-			<xs:enumeration value="BH" />
-			<!-- Burundi -->
-			<xs:enumeration value="BI" />
-			<!-- Benin -->
-			<xs:enumeration value="BJ" />
-			<!-- Saint Barthélemy -->
-			<xs:enumeration value="BL" />
-			<!-- Bermuda -->
-			<xs:enumeration value="BM" />
-			<!-- Brunei Darussalam -->
-			<xs:enumeration value="BN" />
-			<!-- Bolivia (Plurinational State of) -->
-			<xs:enumeration value="BO" />
-			<!-- Bonaire, Sint Eustatius and Saba (Part of the Netherlands) -->
-			<xs:enumeration value="BQ" />
-			<!-- Brazil -->
-			<xs:enumeration value="BR" />
-			<!-- Bahamas -->
-			<xs:enumeration value="BS" />
-			<!-- Bhutan -->
-			<xs:enumeration value="BT" />
-			<!-- Bouvet Island (Dependency of Norway) -->
-			<xs:enumeration value="BV" />
-			<!-- Botswana -->
-			<xs:enumeration value="BW" />
-			<!-- Belarus -->
-			<xs:enumeration value="BY" />
-			<!-- Belize -->
-			<xs:enumeration value="BZ" />
-			<!-- Canada -->
-			<xs:enumeration value="CA" />
-			<!-- Cocos (Keeling) Islands (External territory of Australia) -->
-			<xs:enumeration value="CC" />
-			<!-- Congo, Democratic Republic of the -->
-			<xs:enumeration value="CD" />
-			<!-- Central African Republic -->
-			<xs:enumeration value="CF" />
-			<!-- Congo -->
-			<xs:enumeration value="CG" />
-			<!-- Switzerland -->
-			<xs:enumeration value="CH" />
-			<!-- Côte d'Ivoire -->
-			<xs:enumeration value="CI" />
-			<!-- Cook Islands -->
-			<xs:enumeration value="CK" />
-			<!-- Chile  -->
-			<xs:enumeration value="CL" />
-			<!-- Cameroon -->
-			<xs:enumeration value="CM" />
-			<!-- China -->
-			<xs:enumeration value="CN" />
-			<!-- Colombia -->
-			<xs:enumeration value="CO" />
-			<!-- Costa Rica -->
-			<xs:enumeration value="CR" />
-			<!-- Cuba -->
-			<xs:enumeration value="CU" />
-			<!-- Cabo Verde -->
-			<xs:enumeration value="CV" />
-			<!-- Curaçao -->
-			<xs:enumeration value="CW" />
-			<!-- Christmas Island -->
-			<xs:enumeration value="CX" />
-			<!-- Cyprus -->
-			<xs:enumeration value="CY" />
-			<!-- Czechia -->
-			<xs:enumeration value="CZ" />
-			<!-- Germany -->
-			<xs:enumeration value="DE" />
-			<!-- Djibouti -->
-			<xs:enumeration value="DJ" />
-			<!-- Denmark -->
-			<xs:enumeration value="DK" />
-			<!-- Dominica -->
-			<xs:enumeration value="DM" />
-			<!-- Dominican Republic -->
-			<xs:enumeration value="DO" />
-			<!-- Algeria -->
-			<xs:enumeration value="DZ" />
-			<!-- Ecuador -->
-			<xs:enumeration value="EC" />
-			<!-- Estonia -->
-			<xs:enumeration value="EE" />
-			<!-- Egypt -->
-			<xs:enumeration value="EG" />
-			<!-- Western Sahara -->
-			<xs:enumeration value="EH" />
-			<!-- Eritrea -->
-			<xs:enumeration value="ER" />
-			<!-- Spain -->
-			<xs:enumeration value="ES" />
-			<!-- Ethiopia -->
-			<xs:enumeration value="ET" />
-			<!-- Finland -->
-			<xs:enumeration value="FI" />
-			<!-- Fiji -->
-			<xs:enumeration value="FJ" />
-			<!-- Falkland Islands (Malvinas) -->
-			<xs:enumeration value="FK" />
-			<!-- Micronesia (Federated States of) -->
-			<xs:enumeration value="FM" />
-			<!-- Faroe Islands -->
-			<xs:enumeration value="FO" />
-			<!-- France -->
-			<xs:enumeration value="FR" />
-			<!-- Gabon -->
-			<xs:enumeration value="GA" />
-			<!-- United Kingdom of Great Britain and Northern Ireland -->
-			<xs:enumeration value="GB" />
-			<!-- Grenada -->
-			<xs:enumeration value="GD" />
-			<!-- Georgia -->
-			<xs:enumeration value="GE" />
-			<!-- French Guiana -->
-			<xs:enumeration value="GF" />
-			<!-- Guernsey (A British Crown Dependency) -->
-			<xs:enumeration value="GG" />
-			<!-- Ghana -->
-			<xs:enumeration value="GH" />
-			<!-- Gibraltar -->
-			<xs:enumeration value="GI" />
-			<!-- Greenland -->
-			<xs:enumeration value="GL" />
-			<!-- Gambia -->
-			<xs:enumeration value="GM" />
-			<!-- Guinea -->
-			<xs:enumeration value="GN" />
-			<!-- Guadeloupe -->
-			<xs:enumeration value="GP" />
-			<!-- Equatorial Guinea -->
-			<xs:enumeration value="GQ" />
-			<!-- Greece -->
-			<xs:enumeration value="GR" />
-			<!-- South Georgia and the South Sandwich Islands -->
-			<xs:enumeration value="GS" />
-			<!-- Guatemala -->
-			<xs:enumeration value="GT" />
-			<!-- Guam -->
-			<xs:enumeration value="GU" />
-			<!-- Guinea-Bissau -->
-			<xs:enumeration value="GW" />
-			<!-- Guyana  -->
-			<xs:enumeration value="GY" />
-			<!-- Hong Kong -->
-			<xs:enumeration value="HK" />
-			<!-- Heard Island and McDonald Islands (External territory of Australia) -->
-			<xs:enumeration value="HM" />
-			<!-- Honduras -->
-			<xs:enumeration value="HN" />
-			<!-- Croatia -->
-			<xs:enumeration value="HR" />
-			<!-- Haiti -->
-			<xs:enumeration value="HT" />
-			<!-- Hungary  -->
-			<xs:enumeration value="HU" />
-			<!-- Indonesia -->
-			<xs:enumeration value="ID" />
-			<!-- Ireland -->
-			<xs:enumeration value="IE" />
-			<!-- Israel -->
-			<xs:enumeration value="IL" />
-			<!-- Isle of Man (A British Crown Dependency) -->
-			<xs:enumeration value="IM" />
-			<!-- India -->
-			<xs:enumeration value="IN" />
-			<!-- British Indian Ocean Territory -->
-			<xs:enumeration value="IO" />
-			<!-- Iraq -->
-			<xs:enumeration value="IQ" />
-			<!-- Iran (Islamic Republic of) -->
-			<xs:enumeration value="IR" />
-			<!-- Iceland -->
-			<xs:enumeration value="IS" />
-			<!-- Italy -->
-			<xs:enumeration value="IT" />
-			<!-- Jersey (A British Crown Dependency) -->
-			<xs:enumeration value="JE" />
-			<!-- Jamaica -->
-			<xs:enumeration value="JM" />
-			<!-- Jordan  -->
-			<xs:enumeration value="JO" />
-			<!-- Japan -->
-			<xs:enumeration value="JP" />
-			<!-- Kenya -->
-			<xs:enumeration value="KE" />
-			<!-- Kyrgyzstan -->
-			<xs:enumeration value="KG" />
-			<!-- Cambodia -->
-			<xs:enumeration value="KH" />
-			<!-- Kiribati -->
-			<xs:enumeration value="KI" />
-			<!-- Comoros -->
-			<xs:enumeration value="KM" />
-			<!-- Saint Kitts and Nevis -->
-			<xs:enumeration value="KN" />
-			<!-- Korea (Democratic People's Republic of) (common name: North Korea) -->
-			<xs:enumeration value="KP" />
-			<!-- Korea, Republic of (common name: South Korea) -->
-			<xs:enumeration value="KR" />
-			<!-- Kuwait -->
-			<xs:enumeration value="KW" />
-			<!-- Cayman Islands -->
-			<xs:enumeration value="KY" />
-			<!-- Kazakhstan -->
-			<xs:enumeration value="KZ" />
-			<!-- Lao People's Democratic Republic -->
-			<xs:enumeration value="LA" />
-			<!-- Lebanon -->
-			<xs:enumeration value="LB" />
-			<!-- Saint Lucia -->
-			<xs:enumeration value="LC" />
-			<!-- Liechtenstein -->
-			<xs:enumeration value="LI" />
-			<!-- Sri Lanka  -->
-			<xs:enumeration value="LK" />
-			<!-- Liberia -->
-			<xs:enumeration value="LR" />
-			<!-- Lesotho -->
-			<xs:enumeration value="LS" />
-			<!-- Lithuania  -->
-			<xs:enumeration value="LT" />
-			<!-- Luxembourg -->
-			<xs:enumeration value="LU" />
-			<!-- Latvia -->
-			<xs:enumeration value="LV" />
-			<!-- Libya -->
-			<xs:enumeration value="LY" />
-			<!-- Morocco -->
-			<xs:enumeration value="MA" />
-			<!-- Monaco -->
-			<xs:enumeration value="MC" />
-			<!-- Moldova, Republic of -->
-			<xs:enumeration value="MD" />
-			<!-- Montenegro -->
-			<xs:enumeration value="ME" />
-			<!-- Saint Martin (French part) -->
-			<xs:enumeration value="MF" />
-			<!-- Madagascar -->
-			<xs:enumeration value="MG" />
-			<!-- Marshall Islands -->
-			<xs:enumeration value="MH" />
-			<!-- North Macedonia -->
-			<xs:enumeration value="MK" />
-			<!-- Mali -->
-			<xs:enumeration value="ML" />
-			<!-- Myanmar -->
-			<xs:enumeration value="MM" />
-			<!-- Mongolia -->
-			<xs:enumeration value="MN" />
-			<!-- Macao -->
-			<xs:enumeration value="MO" />
-			<!-- Northern Mariana Islands -->
-			<xs:enumeration value="MP" />
-			<!-- Martinique -->
-			<xs:enumeration value="MQ" />
-			<!-- Mauritania -->
-			<xs:enumeration value="MR" />
-			<!-- Montserrat -->
-			<xs:enumeration value="MS" />
-			<!-- Malta -->
-			<xs:enumeration value="MT" />
-			<!-- Mauritius -->
-			<xs:enumeration value="MU" />
-			<!-- Maldives -->
-			<xs:enumeration value="MV" />
-			<!-- Malawi -->
-			<xs:enumeration value="MW" />
-			<!-- Mexico -->
-			<xs:enumeration value="MX" />
-			<!-- Malaysia -->
-			<xs:enumeration value="MY" />
-			<!-- Mozambique -->
-			<xs:enumeration value="MZ" />
-			<!-- Namibia -->
-			<xs:enumeration value="NA" />
-			<!-- New Caledonia -->
-			<xs:enumeration value="NC" />
-			<!-- Niger -->
-			<xs:enumeration value="NE" />
-			<!-- Norfolk Island (External territory of Australia) -->
-			<xs:enumeration value="NF" />
-			<!-- Nigeria -->
-			<xs:enumeration value="NG" />
-			<!-- Nicaragua -->
-			<xs:enumeration value="NI" />
-			<!-- Netherlands, Kingdom of the -->
-			<xs:enumeration value="NL" />
-			<!-- Norway -->
-			<xs:enumeration value="NO" />
-			<!-- Nepal -->
-			<xs:enumeration value="NP" />
-			<!-- Nauru -->
-			<xs:enumeration value="NR" />
-			<!-- Niue -->
-			<xs:enumeration value="NU" />
-			<!-- New Zealand -->
-			<xs:enumeration value="NZ" />
-			<!-- Oman -->
-			<xs:enumeration value="OM" />
-			<!-- Panama -->
-			<xs:enumeration value="PA" />
-			<!-- Peru -->
-			<xs:enumeration value="PE" />
-			<!-- French Polynesia -->
-			<xs:enumeration value="PF" />
-			<!-- Papua New Guinea -->
-			<xs:enumeration value="PG" />
-			<!-- Philippines -->
-			<xs:enumeration value="PH" />
-			<!-- Pakistan -->
-			<xs:enumeration value="PK" />
-			<!-- Poland -->
-			<xs:enumeration value="PL" />
-			<!-- Saint Pierre and Miquelon -->
-			<xs:enumeration value="PM" />
-			<!-- Pitcairn -->
-			<xs:enumeration value="PN" />
-			<!-- Puerto Rico -->
-			<xs:enumeration value="PR" />
-			<!-- Palestine, State of -->
-			<xs:enumeration value="PS" />
-			<!-- Portugal -->
-			<xs:enumeration value="PT" />
-			<!-- Palau -->
-			<xs:enumeration value="PW" />
-			<!-- Paraguay -->
-			<xs:enumeration value="PY" />
-			<!-- Qatar -->
-			<xs:enumeration value="QA" />
-			<!-- Réunion -->
-			<xs:enumeration value="RE" />
-			<!-- Romania -->
-			<xs:enumeration value="RO" />
-			<!-- Serbia -->
-			<xs:enumeration value="RS" />
-			<!-- Russian Federation -->
-			<xs:enumeration value="RU" />
-			<!-- Rwanda -->
-			<xs:enumeration value="RW" />
-			<!-- Saudi Arabia -->
-			<xs:enumeration value="SA" />
-			<!-- Solomon Islands -->
-			<xs:enumeration value="SB" />
-			<!-- Seychelles -->
-			<xs:enumeration value="SC" />
-			<!-- Sudan -->
-			<xs:enumeration value="SD" />
-			<!-- Sweden -->
-			<xs:enumeration value="SE" />
-			<!-- Singapore -->
-			<xs:enumeration value="SG" />
-			<!-- Saint Helena, Ascension and Tristan da Cunha -->
-			<xs:enumeration value="SH" />
-			<!-- Slovenia -->
-			<xs:enumeration value="SI" />
-			<!-- Svalbard and Jan Mayen -->
-			<xs:enumeration value="SJ" />
-			<!-- Slovakia -->
-			<xs:enumeration value="SK" />
-			<!-- Sierra Leone -->
-			<xs:enumeration value="SL" />
-			<!-- San Marino -->
-			<xs:enumeration value="SM" />
-			<!-- Senegal -->
-			<xs:enumeration value="SN" />
-			<!-- Somalia -->
-			<xs:enumeration value="SO" />
-			<!-- Suriname -->
-			<xs:enumeration value="SR" />
-			<!-- South Sudan -->
-			<xs:enumeration value="SS" />
-			<!-- Sao Tome and Principe -->
-			<xs:enumeration value="ST" />
-			<!-- El Salvador -->
-			<xs:enumeration value="SV" />
-			<!-- Sint Maarten (Dutch part) -->
-			<xs:enumeration value="SX" />
-			<!-- Syrian Arab Republic -->
-			<xs:enumeration value="SY" />
-			<!-- Eswatini -->
-			<xs:enumeration value="SZ" />
-			<!-- Turks and Caicos Islands -->
-			<xs:enumeration value="TC" />
-			<!-- Chad -->
-			<xs:enumeration value="TD" />
-			<!-- French Southern Territories -->
-			<xs:enumeration value="TF" />
-			<!-- Togo -->
-			<xs:enumeration value="TG" />
-			<!-- Thailand -->
-			<xs:enumeration value="TH" />
-			<!-- Tajikistan -->
-			<xs:enumeration value="TJ" />
-			<!-- Tokelau -->
-			<xs:enumeration value="TK" />
-			<!-- Timor-Leste -->
-			<xs:enumeration value="TL" />
-			<!-- Turkmenistan -->
-			<xs:enumeration value="TM" />
-			<!-- Tunisia -->
-			<xs:enumeration value="TN" />
-			<!-- Tonga -->
-			<xs:enumeration value="TO" />
-			<!-- Türkiye -->
-			<xs:enumeration value="TR" />
-			<!-- Trinidad and Tobago -->
-			<xs:enumeration value="TT" />
-			<!-- Tuvalu -->
-			<xs:enumeration value="TV" />
-			<!-- Taiwan, Province of China -->
-			<xs:enumeration value="TW" />
-			<!-- Tanzania, United Republic of -->
-			<xs:enumeration value="TZ" />
-			<!-- Ukraine -->
-			<xs:enumeration value="UA" />
-			<!-- Uganda -->
-			<xs:enumeration value="UG" />
-			<!-- United States Minor Outlying Islands -->
-			<xs:enumeration value="UM" />
-			<!-- United States of America -->
-			<xs:enumeration value="US" />
-			<!-- Uruguay -->
-			<xs:enumeration value="UY" />
-			<!-- Uzbekistan -->
-			<xs:enumeration value="UZ" />
-			<!-- Holy See -->
-			<xs:enumeration value="VA" />
-			<!-- Saint Vincent and the Grenadines -->
-			<xs:enumeration value="VC" />
-			<!-- Venezuela (Bolivarian Republic of) -->
-			<xs:enumeration value="VE" />
-			<!-- Virgin Islands (British) -->
-			<xs:enumeration value="VG" />
-			<!-- Virgin Islands (U.S.) -->
-			<xs:enumeration value="VI" />
-			<!-- Viet Nam -->
-			<xs:enumeration value="VN" />
-			<!-- Vanuatu -->
-			<xs:enumeration value="VU" />
-			<!-- Wallis and Futuna -->
-			<xs:enumeration value="WF" />
-			<!-- Samoa -->
-			<xs:enumeration value="WS" />
-			<!-- Yemen -->
-			<xs:enumeration value="YE" />
-			<!-- Mayotte -->
-			<xs:enumeration value="YT" />
-			<!-- South Africa -->
-			<xs:enumeration value="ZA" />
-			<!-- Zambia -->
-			<xs:enumeration value="ZM" />
-			<!-- Zimbabwe -->
-			<xs:enumeration value="ZW" />
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="countryIso3Type" id="countryIso3Type">
-		<xs:annotation>
-			<xs:documentation>Three-letter ISO 3166-1 alpha-3 country code.</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="ABW" />
-			<!-- Aruba -->
-			<xs:enumeration value="AFG" />
-			<!-- Afghanistan -->
-			<xs:enumeration value="AGO" />
-			<!-- Angola -->
-			<xs:enumeration value="AIA" />
-			<!-- Anguilla -->
-			<xs:enumeration value="ALA" />
-			<!-- Åland Islands -->
-			<xs:enumeration value="ALB" />
-			<!-- Albania -->
-			<xs:enumeration value="AND" />
-			<!-- Andorra -->
-			<xs:enumeration value="ARE" />
-			<!-- United Arab Emirates -->
-			<xs:enumeration value="ARG" />
-			<!-- Argentina -->
-			<xs:enumeration value="ARM" />
-			<!-- Armenia -->
-			<xs:enumeration value="ASM" />
-			<!-- American Samoa -->
-			<xs:enumeration value="ATA" />
-			<!-- Antarctica -->
-			<xs:enumeration value="ATF" />
-			<!-- French Southern Territories -->
-			<xs:enumeration value="ATG" />
-			<!-- Antigua and Barbuda -->
-			<xs:enumeration value="AUS" />
-			<!-- Australia -->
-			<xs:enumeration value="AUT" />
-			<!-- Austria -->
-			<xs:enumeration value="AZE" />
-			<!-- Azerbaijan -->
-			<xs:enumeration value="BDI" />
-			<!-- Burundi -->
-			<xs:enumeration value="BEL" />
-			<!-- Belgium -->
-			<xs:enumeration value="BEN" />
-			<!-- Benin -->
-			<xs:enumeration value="BES" />
-			<!-- Bonaire, Sint Eustatius and Saba -->
-			<xs:enumeration value="BFA" />
-			<!-- Burkina Faso -->
-			<xs:enumeration value="BGD" />
-			<!-- Bangladesh -->
-			<xs:enumeration value="BGR" />
-			<!-- Bulgaria -->
-			<xs:enumeration value="BHR" />
-			<!-- Bahrain -->
-			<xs:enumeration value="BHS" />
-			<!-- Bahamas -->
-			<xs:enumeration value="BIH" />
-			<!-- Bosnia and Herzegovina -->
-			<xs:enumeration value="BLM" />
-			<!-- Saint Barthélemy -->
-			<xs:enumeration value="BLR" />
-			<!-- Belarus -->
-			<xs:enumeration value="BLZ" />
-			<!-- Belize -->
-			<xs:enumeration value="BMU" />
-			<!-- Bermuda -->
-			<xs:enumeration value="BOL" />
-			<!-- Bolivia, Plurinational State of -->
-			<xs:enumeration value="BRA" />
-			<!-- Brazil -->
-			<xs:enumeration value="BRB" />
-			<!-- Barbados -->
-			<xs:enumeration value="BRN" />
-			<!-- Brunei Darussalam -->
-			<xs:enumeration value="BTN" />
-			<!-- Bhutan -->
-			<xs:enumeration value="BVT" />
-			<!-- Bouvet Island -->
-			<xs:enumeration value="BWA" />
-			<!-- Botswana -->
-			<xs:enumeration value="CAF" />
-			<!-- Central African Republic -->
-			<xs:enumeration value="CAN" />
-			<!-- Canada -->
-			<xs:enumeration value="CCK" />
-			<!-- Cocos (Keeling) Islands -->
-			<xs:enumeration value="CHE" />
-			<!-- Switzerland -->
-			<xs:enumeration value="CHL" />
-			<!-- Chile -->
-			<xs:enumeration value="CHN" />
-			<!-- China -->
-			<xs:enumeration value="CIV" />
-			<!-- Côte d'Ivoire -->
-			<xs:enumeration value="CMR" />
-			<!-- Cameroon -->
-			<xs:enumeration value="COD" />
-			<!-- Congo, Democratic Republic of the -->
-			<xs:enumeration value="COG" />
-			<!-- Congo -->
-			<xs:enumeration value="COK" />
-			<!-- Cook Islands -->
-			<xs:enumeration value="COL" />
-			<!-- Colombia -->
-			<xs:enumeration value="COM" />
-			<!-- Comoros -->
-			<xs:enumeration value="CPV" />
-			<!-- Cabo Verde -->
-			<xs:enumeration value="CRI" />
-			<!-- Costa Rica -->
-			<xs:enumeration value="CUB" />
-			<!-- Cuba -->
-			<xs:enumeration value="CUW" />
-			<!-- Curaçao -->
-			<xs:enumeration value="CXR" />
-			<!-- Christmas Island -->
-			<xs:enumeration value="CYM" />
-			<!-- Cayman Islands -->
-			<xs:enumeration value="CYP" />
-			<!-- Cyprus -->
-			<xs:enumeration value="CZE" />
-			<!-- Czechia -->
-			<xs:enumeration value="DEU" />
-			<!-- Germany -->
-			<xs:enumeration value="DJI" />
-			<!-- Djibouti -->
-			<xs:enumeration value="DMA" />
-			<!-- Dominica -->
-			<xs:enumeration value="DNK" />
-			<!-- Denmark -->
-			<xs:enumeration value="DOM" />
-			<!-- Dominican Republic -->
-			<xs:enumeration value="DZA" />
-			<!-- Algeria -->
-			<xs:enumeration value="ECU" />
-			<!-- Ecuador -->
-			<xs:enumeration value="EGY" />
-			<!-- Egypt -->
-			<xs:enumeration value="ERI" />
-			<!-- Eritrea -->
-			<xs:enumeration value="ESH" />
-			<!-- Western Sahara -->
-			<xs:enumeration value="ESP" />
-			<!-- Spain -->
-			<xs:enumeration value="EST" />
-			<!-- Estonia -->
-			<xs:enumeration value="ETH" />
-			<!-- Ethiopia -->
-			<xs:enumeration value="FIN" />
-			<!-- Finland -->
-			<xs:enumeration value="FJI" />
-			<!-- Fiji -->
-			<xs:enumeration value="FLK" />
-			<!-- Falkland Islands (Malvinas) -->
-			<xs:enumeration value="FRA" />
-			<!-- France -->
-			<xs:enumeration value="FRO" />
-			<!-- Faroe Islands -->
-			<xs:enumeration value="FSM" />
-			<!-- Micronesia, Federated States of -->
-			<xs:enumeration value="GAB" />
-			<!-- Gabon -->
-			<xs:enumeration value="GBR" />
-			<!-- United Kingdom of Great Britain and Northern Ireland -->
-			<xs:enumeration value="GEO" />
-			<!-- Georgia -->
-			<xs:enumeration value="GGY" />
-			<!-- Guernsey -->
-			<xs:enumeration value="GHA" />
-			<!-- Ghana -->
-			<xs:enumeration value="GIB" />
-			<!-- Gibraltar -->
-			<xs:enumeration value="GIN" />
-			<!-- Guinea -->
-			<xs:enumeration value="GLP" />
-			<!-- Guadeloupe -->
-			<xs:enumeration value="GMB" />
-			<!-- Gambia -->
-			<xs:enumeration value="GNB" />
-			<!-- Guinea-Bissau -->
-			<xs:enumeration value="GNQ" />
-			<!-- Equatorial Guinea -->
-			<xs:enumeration value="GRC" />
-			<!-- Greece -->
-			<xs:enumeration value="GRD" />
-			<!-- Grenada -->
-			<xs:enumeration value="GRL" />
-			<!-- Greenland -->
-			<xs:enumeration value="GTM" />
-			<!-- Guatemala -->
-			<xs:enumeration value="GUF" />
-			<!-- French Guiana -->
-			<xs:enumeration value="GUM" />
-			<!-- Guam -->
-			<xs:enumeration value="GUY" />
-			<!-- Guyana -->
-			<xs:enumeration value="HKG" />
-			<!-- Hong Kong -->
-			<xs:enumeration value="HMD" />
-			<!-- Heard Island and McDonald Islands -->
-			<xs:enumeration value="HND" />
-			<!-- Honduras -->
-			<xs:enumeration value="HRV" />
-			<!-- Croatia -->
-			<xs:enumeration value="HTI" />
-			<!-- Haiti -->
-			<xs:enumeration value="HUN" />
-			<!-- Hungary -->
-			<xs:enumeration value="IDN" />
-			<!-- Indonesia -->
-			<xs:enumeration value="IMN" />
-			<!-- Isle of Man -->
-			<xs:enumeration value="IND" />
-			<!-- India -->
-			<xs:enumeration value="IOT" />
-			<!-- British Indian Ocean Territory -->
-			<xs:enumeration value="IRL" />
-			<!-- Ireland -->
-			<xs:enumeration value="IRN" />
-			<!-- Iran, Islamic Republic of -->
-			<xs:enumeration value="IRQ" />
-			<!-- Iraq -->
-			<xs:enumeration value="ISL" />
-			<!-- Iceland -->
-			<xs:enumeration value="ISR" />
-			<!-- Israel -->
-			<xs:enumeration value="ITA" />
-			<!-- Italy -->
-			<xs:enumeration value="JAM" />
-			<!-- Jamaica -->
-			<xs:enumeration value="JEY" />
-			<!-- Jersey -->
-			<xs:enumeration value="JOR" />
-			<!-- Jordan -->
-			<xs:enumeration value="JPN" />
-			<!-- Japan -->
-			<xs:enumeration value="KAZ" />
-			<!-- Kazakhstan -->
-			<xs:enumeration value="KEN" />
-			<!-- Kenya -->
-			<xs:enumeration value="KGZ" />
-			<!-- Kyrgyzstan -->
-			<xs:enumeration value="KHM" />
-			<!-- Cambodia -->
-			<xs:enumeration value="KIR" />
-			<!-- Kiribati -->
-			<xs:enumeration value="KNA" />
-			<!-- Saint Kitts and Nevis -->
-			<xs:enumeration value="KOR" />
-			<!-- Korea, Republic of -->
-			<xs:enumeration value="KWT" />
-			<!-- Kuwait -->
-			<xs:enumeration value="LAO" />
-			<!-- Lao People's Democratic Republic -->
-			<xs:enumeration value="LBN" />
-			<!-- Lebanon -->
-			<xs:enumeration value="LBR" />
-			<!-- Liberia -->
-			<xs:enumeration value="LBY" />
-			<!-- Libya -->
-			<xs:enumeration value="LCA" />
-			<!-- Saint Lucia -->
-			<xs:enumeration value="LIE" />
-			<!-- Liechtenstein -->
-			<xs:enumeration value="LKA" />
-			<!-- Sri Lanka -->
-			<xs:enumeration value="LSO" />
-			<!-- Lesotho -->
-			<xs:enumeration value="LTU" />
-			<!-- Lithuania -->
-			<xs:enumeration value="LUX" />
-			<!-- Luxembourg -->
-			<xs:enumeration value="LVA" />
-			<!-- Latvia -->
-			<xs:enumeration value="MAC" />
-			<!-- Macao -->
-			<xs:enumeration value="MAF" />
-			<!-- Saint Martin (French part) -->
-			<xs:enumeration value="MAR" />
-			<!-- Morocco -->
-			<xs:enumeration value="MCO" />
-			<!-- Monaco -->
-			<xs:enumeration value="MDA" />
-			<!-- Moldova, Republic of -->
-			<xs:enumeration value="MDG" />
-			<!-- Madagascar -->
-			<xs:enumeration value="MDV" />
-			<!-- Maldives -->
-			<xs:enumeration value="MEX" />
-			<!-- Mexico -->
-			<xs:enumeration value="MHL" />
-			<!-- Marshall Islands -->
-			<xs:enumeration value="MKD" />
-			<!-- North Macedonia -->
-			<xs:enumeration value="MLI" />
-			<!-- Mali -->
-			<xs:enumeration value="MLT" />
-			<!-- Malta -->
-			<xs:enumeration value="MMR" />
-			<!-- Myanmar -->
-			<xs:enumeration value="MNE" />
-			<!-- Montenegro -->
-			<xs:enumeration value="MNG" />
-			<!-- Mongolia -->
-			<xs:enumeration value="MNP" />
-			<!-- Northern Mariana Islands -->
-			<xs:enumeration value="MOZ" />
-			<!-- Mozambique -->
-			<xs:enumeration value="MRT" />
-			<!-- Mauritania -->
-			<xs:enumeration value="MSR" />
-			<!-- Montserrat -->
-			<xs:enumeration value="MTQ" />
-			<!-- Martinique -->
-			<xs:enumeration value="MUS" />
-			<!-- Mauritius -->
-			<xs:enumeration value="MWI" />
-			<!-- Malawi -->
-			<xs:enumeration value="MYS" />
-			<!-- Malaysia -->
-			<xs:enumeration value="MYT" />
-			<!-- Mayotte -->
-			<xs:enumeration value="NAM" />
-			<!-- Namibia -->
-			<xs:enumeration value="NCL" />
-			<!-- New Caledonia -->
-			<xs:enumeration value="NER" />
-			<!-- Niger -->
-			<xs:enumeration value="NFK" />
-			<!-- Norfolk Island -->
-			<xs:enumeration value="NGA" />
-			<!-- Nigeria -->
-			<xs:enumeration value="NIC" />
-			<!-- Nicaragua -->
-			<xs:enumeration value="NIU" />
-			<!-- Niue -->
-			<xs:enumeration value="NLD" />
-			<!-- Netherlands, Kingdom of the -->
-			<xs:enumeration value="NOR" />
-			<!-- Norway -->
-			<xs:enumeration value="NPL" />
-			<!-- Nepal -->
-			<xs:enumeration value="NRU" />
-			<!-- Nauru -->
-			<xs:enumeration value="NZL" />
-			<!-- New Zealand -->
-			<xs:enumeration value="OMN" />
-			<!-- Oman -->
-			<xs:enumeration value="PAK" />
-			<!-- Pakistan -->
-			<xs:enumeration value="PAN" />
-			<!-- Panama -->
-			<xs:enumeration value="PCN" />
-			<!-- Pitcairn -->
-			<xs:enumeration value="PER" />
-			<!-- Peru -->
-			<xs:enumeration value="PHL" />
-			<!-- Philippines -->
-			<xs:enumeration value="PLW" />
-			<!-- Palau -->
-			<xs:enumeration value="PNG" />
-			<!-- Papua New Guinea -->
-			<xs:enumeration value="POL" />
-			<!-- Poland -->
-			<xs:enumeration value="PRI" />
-			<!-- Puerto Rico -->
-			<xs:enumeration value="PRK" />
-			<!-- Korea, Democratic People's Republic of -->
-			<xs:enumeration value="PRT" />
-			<!-- Portugal -->
-			<xs:enumeration value="PRY" />
-			<!-- Paraguay -->
-			<xs:enumeration value="PSE" />
-			<!-- Palestine, State of -->
-			<xs:enumeration value="PYF" />
-			<!-- French Polynesia -->
-			<xs:enumeration value="QAT" />
-			<!-- Qatar -->
-			<xs:enumeration value="REU" />
-			<!-- Réunion -->
-			<xs:enumeration value="ROU" />
-			<!-- Romania -->
-			<xs:enumeration value="RUS" />
-			<!-- Russian Federation -->
-			<xs:enumeration value="RWA" />
-			<!-- Rwanda -->
-			<xs:enumeration value="SAU" />
-			<!-- Saudi Arabia -->
-			<xs:enumeration value="SDN" />
-			<!-- Sudan -->
-			<xs:enumeration value="SEN" />
-			<!-- Senegal -->
-			<xs:enumeration value="SGP" />
-			<!-- Singapore -->
-			<xs:enumeration value="SGS" />
-			<!-- South Georgia and the South Sandwich Islands -->
-			<xs:enumeration value="SHN" />
-			<!-- Saint Helena, Ascension and Tristan da Cunha -->
-			<xs:enumeration value="SJM" />
-			<!-- Svalbard and Jan Mayen -->
-			<xs:enumeration value="SLB" />
-			<!-- Solomon Islands -->
-			<xs:enumeration value="SLE" />
-			<!-- Sierra Leone -->
-			<xs:enumeration value="SLV" />
-			<!-- El Salvador -->
-			<xs:enumeration value="SMR" />
-			<!-- San Marino -->
-			<xs:enumeration value="SOM" />
-			<!-- Somalia -->
-			<xs:enumeration value="SPM" />
-			<!-- Saint Pierre and Miquelon -->
-			<xs:enumeration value="SRB" />
-			<!-- Serbia -->
-			<xs:enumeration value="SSD" />
-			<!-- South Sudan -->
-			<xs:enumeration value="STP" />
-			<!-- Sao Tome and Principe -->
-			<xs:enumeration value="SUR" />
-			<!-- Suriname -->
-			<xs:enumeration value="SVK" />
-			<!-- Slovakia -->
-			<xs:enumeration value="SVN" />
-			<!-- Slovenia -->
-			<xs:enumeration value="SWE" />
-			<!-- Sweden -->
-			<xs:enumeration value="SWZ" />
-			<!-- Eswatini -->
-			<xs:enumeration value="SXM" />
-			<!-- Sint Maarten (Dutch part) -->
-			<xs:enumeration value="SYC" />
-			<!-- Seychelles -->
-			<xs:enumeration value="SYR" />
-			<!-- Syrian Arab Republic -->
-			<xs:enumeration value="TCA" />
-			<!-- Turks and Caicos Islands -->
-			<xs:enumeration value="TCD" />
-			<!-- Chad -->
-			<xs:enumeration value="TGO" />
-			<!-- Togo -->
-			<xs:enumeration value="THA" />
-			<!-- Thailand -->
-			<xs:enumeration value="TJK" />
-			<!-- Tajikistan -->
-			<xs:enumeration value="TKL" />
-			<!-- Tokelau -->
-			<xs:enumeration value="TKM" />
-			<!-- Turkmenistan -->
-			<xs:enumeration value="TLS" />
-			<!-- Timor-Leste -->
-			<xs:enumeration value="TON" />
-			<!-- Tonga -->
-			<xs:enumeration value="TTO" />
-			<!-- Trinidad and Tobago -->
-			<xs:enumeration value="TUN" />
-			<!-- Tunisia -->
-			<xs:enumeration value="TUR" />
-			<!-- Türkiye -->
-			<xs:enumeration value="TUV" />
-			<!-- Tuvalu -->
-			<xs:enumeration value="TWN" />
-			<!-- Taiwan, Province of China -->
-			<xs:enumeration value="TZA" />
-			<!-- Tanzania, United Republic of -->
-			<xs:enumeration value="UGA" />
-			<!-- Uganda -->
-			<xs:enumeration value="UKR" />
-			<!-- Ukraine -->
-			<xs:enumeration value="UMI" />
-			<!-- United States Minor Outlying Islands -->
-			<xs:enumeration value="URY" />
-			<!-- Uruguay -->
-			<xs:enumeration value="USA" />
-			<!-- United States of America -->
-			<xs:enumeration value="UZB" />
-			<!-- Uzbekistan -->
-			<xs:enumeration value="VAT" />
-			<!-- Holy See -->
-			<xs:enumeration value="VCT" />
-			<!-- Saint Vincent and the Grenadines -->
-			<xs:enumeration value="VEN" />
-			<!-- Venezuela, Bolivarian Republic of -->
-			<xs:enumeration value="VGB" />
-			<!-- Virgin Islands (British) -->
-			<xs:enumeration value="VIR" />
-			<!-- Virgin Islands (U.S.) -->
-			<xs:enumeration value="VNM" />
-			<!-- Viet Nam -->
-			<xs:enumeration value="VUT" />
-			<!-- Vanuatu -->
-			<xs:enumeration value="WLF" />
-			<!-- Wallis and Futuna -->
-			<xs:enumeration value="WSM" />
-			<!-- Samoa -->
-			<xs:enumeration value="YEM" />
-			<!-- Yemen -->
-			<xs:enumeration value="ZAF" />
-			<!-- South Africa -->
-			<xs:enumeration value="ZMB" />
-			<!-- Zambia -->
-			<xs:enumeration value="ZWE" />
-			<!-- Zimbabwe -->
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="languageIso2Type" id="languageIso2Type">
-		<xs:annotation>
-			<xs:documentation>Three-letter ISO 639-2/T language code.</xs:documentation>
-		</xs:annotation>
-		<xs:enumeration value="AAR" />
-		<xs:enumeration value="ABK" />
-		<xs:enumeration value="ACE" />
-		<xs:enumeration value="ACH" />
-		<xs:enumeration value="ADA" />
-		<xs:enumeration value="ADY" />
-		<xs:enumeration value="AFA" />
-		<xs:enumeration value="AFH" />
-		<xs:enumeration value="AFR" />
-		<xs:enumeration value="AIN" />
-		<xs:enumeration value="AKA" />
-		<xs:enumeration value="AKK" />
-		<xs:enumeration value="SQI" />
-		<xs:enumeration value="ALE" />
-		<xs:enumeration value="ALG" />
-		<xs:enumeration value="ALT" />
-		<xs:enumeration value="AMH" />
-		<xs:enumeration value="ANG" />
-		<xs:enumeration value="ANP" />
-		<xs:enumeration value="APA" />
-		<xs:enumeration value="ARA" />
-		<xs:enumeration value="ARC" />
-		<xs:enumeration value="ARG" />
-		<xs:enumeration value="HYE" />
-		<xs:enumeration value="ARN" />
-		<xs:enumeration value="ARP" />
-		<xs:enumeration value="ART" />
-		<xs:enumeration value="ARW" />
-		<xs:enumeration value="ASM" />
-		<xs:enumeration value="AST" />
-		<xs:enumeration value="ATH" />
-		<xs:enumeration value="AUS" />
-		<xs:enumeration value="AVA" />
-		<xs:enumeration value="AVE" />
-		<xs:enumeration value="AWA" />
-		<xs:enumeration value="AYM" />
-		<xs:enumeration value="AZE" />
-		<xs:enumeration value="BAD" />
-		<xs:enumeration value="BAI" />
-		<xs:enumeration value="BAK" />
-		<xs:enumeration value="BAL" />
-		<xs:enumeration value="BAM" />
-		<xs:enumeration value="BAN" />
-		<xs:enumeration value="EUS" />
-		<xs:enumeration value="BAS" />
-		<xs:enumeration value="BAT" />
-		<xs:enumeration value="BEJ" />
-		<xs:enumeration value="BEL" />
-		<xs:enumeration value="BEM" />
-		<xs:enumeration value="BEN" />
-		<xs:enumeration value="BER" />
-		<xs:enumeration value="BHO" />
-		<xs:enumeration value="BIH" />
-		<xs:enumeration value="BIK" />
-		<xs:enumeration value="BIN" />
-		<xs:enumeration value="BIS" />
-		<xs:enumeration value="BLA" />
-		<xs:enumeration value="BNT" />
-		<xs:enumeration value="BOS" />
-		<xs:enumeration value="BRA" />
-		<xs:enumeration value="BRE" />
-		<xs:enumeration value="BTK" />
-		<xs:enumeration value="BUA" />
-		<xs:enumeration value="BUG" />
-		<xs:enumeration value="BUL" />
-		<xs:enumeration value="MYA" />
-		<xs:enumeration value="BYN" />
-		<xs:enumeration value="CAD" />
-		<xs:enumeration value="CAI" />
-		<xs:enumeration value="CAR" />
-		<xs:enumeration value="CAT" />
-		<xs:enumeration value="CAU" />
-		<xs:enumeration value="CEB" />
-		<xs:enumeration value="CEL" />
-		<xs:enumeration value="CHA" />
-		<xs:enumeration value="CHB" />
-		<xs:enumeration value="CHE" />
-		<xs:enumeration value="CHG" />
-		<xs:enumeration value="ZHO" />
-		<xs:enumeration value="CHK" />
-		<xs:enumeration value="CHM" />
-		<xs:enumeration value="CHN" />
-		<xs:enumeration value="CHO" />
-		<xs:enumeration value="CHP" />
-		<xs:enumeration value="CHR" />
-		<xs:enumeration value="CHU" />
-		<xs:enumeration value="CHV" />
-		<xs:enumeration value="CHY" />
-		<xs:enumeration value="CMC" />
-		<xs:enumeration value="COP" />
-		<xs:enumeration value="COR" />
-		<xs:enumeration value="COS" />
-		<xs:enumeration value="CPE" />
-		<xs:enumeration value="CPF" />
-		<xs:enumeration value="CPP" />
-		<xs:enumeration value="CRE" />
-		<xs:enumeration value="CRH" />
-		<xs:enumeration value="CRP" />
-		<xs:enumeration value="CSB" />
-		<xs:enumeration value="CUS" />
-		<xs:enumeration value="CES" />
-		<xs:enumeration value="DAK" />
-		<xs:enumeration value="DAN" />
-		<xs:enumeration value="DAR" />
-		<xs:enumeration value="DAY" />
-		<xs:enumeration value="DEL" />
-		<xs:enumeration value="DEN" />
-		<xs:enumeration value="DGR" />
-		<xs:enumeration value="DIN" />
-		<xs:enumeration value="DIV" />
-		<xs:enumeration value="DOI" />
-		<xs:enumeration value="DRA" />
-		<xs:enumeration value="DSB" />
-		<xs:enumeration value="DUA" />
-		<xs:enumeration value="DUM" />
-		<xs:enumeration value="NLD" />
-		<xs:enumeration value="DYU" />
-		<xs:enumeration value="DZO" />
-		<xs:enumeration value="EFI" />
-		<xs:enumeration value="EGY" />
-		<xs:enumeration value="EKA" />
-		<xs:enumeration value="ELX" />
-		<xs:enumeration value="ENG" />
-		<xs:enumeration value="ENM" />
-		<xs:enumeration value="EPO" />
-		<xs:enumeration value="EST" />
-		<xs:enumeration value="EWE" />
-		<xs:enumeration value="EWO" />
-		<xs:enumeration value="FAN" />
-		<xs:enumeration value="FAO" />
-		<xs:enumeration value="FAT" />
-		<xs:enumeration value="FIJ" />
-		<xs:enumeration value="FIL" />
-		<xs:enumeration value="FIN" />
-		<xs:enumeration value="FIU" />
-		<xs:enumeration value="FON" />
-		<xs:enumeration value="FRA" />
-		<xs:enumeration value="FRM" />
-		<xs:enumeration value="FRO" />
-		<xs:enumeration value="FRR" />
-		<xs:enumeration value="FRS" />
-		<xs:enumeration value="FRY" />
-		<xs:enumeration value="FUL" />
-		<xs:enumeration value="FUR" />
-		<xs:enumeration value="GAA" />
-		<xs:enumeration value="GAY" />
-		<xs:enumeration value="GBA" />
-		<xs:enumeration value="GEM" />
-		<xs:enumeration value="KAT" />
-		<xs:enumeration value="DEU" />
-		<xs:enumeration value="GEZ" />
-		<xs:enumeration value="GIL" />
-		<xs:enumeration value="GLA" />
-		<xs:enumeration value="GLE" />
-		<xs:enumeration value="GLG" />
-		<xs:enumeration value="GLV" />
-		<xs:enumeration value="GMH" />
-		<xs:enumeration value="GOH" />
-		<xs:enumeration value="GON" />
-		<xs:enumeration value="GOR" />
-		<xs:enumeration value="GOT" />
-		<xs:enumeration value="GRB" />
-		<xs:enumeration value="GRC" />
-		<xs:enumeration value="ELL" />
-		<xs:enumeration value="GRN" />
-		<xs:enumeration value="GSW" />
-		<xs:enumeration value="GUJ" />
-		<xs:enumeration value="GWI" />
-		<xs:enumeration value="HAI" />
-		<xs:enumeration value="HAT" />
-		<xs:enumeration value="HAU" />
-		<xs:enumeration value="HAW" />
-		<xs:enumeration value="HEB" />
-		<xs:enumeration value="HER" />
-		<xs:enumeration value="HIL" />
-		<xs:enumeration value="HIM" />
-		<xs:enumeration value="HIN" />
-		<xs:enumeration value="HIT" />
-		<xs:enumeration value="HMN" />
-		<xs:enumeration value="HMO" />
-		<xs:enumeration value="HRV" />
-		<xs:enumeration value="HSB" />
-		<xs:enumeration value="HUN" />
-		<xs:enumeration value="HUP" />
-		<xs:enumeration value="IBA" />
-		<xs:enumeration value="IBO" />
-		<xs:enumeration value="ISL" />
-		<xs:enumeration value="IDO" />
-		<xs:enumeration value="III" />
-		<xs:enumeration value="IJO" />
-		<xs:enumeration value="IKU" />
-		<xs:enumeration value="ILE" />
-		<xs:enumeration value="ILO" />
-		<xs:enumeration value="INA" />
-		<xs:enumeration value="INC" />
-		<xs:enumeration value="IND" />
-		<xs:enumeration value="INE" />
-		<xs:enumeration value="INH" />
-		<xs:enumeration value="IPK" />
-		<xs:enumeration value="IRA" />
-		<xs:enumeration value="IRO" />
-		<xs:enumeration value="ITA" />
-		<xs:enumeration value="JAV" />
-		<xs:enumeration value="JBO" />
-		<xs:enumeration value="JPN" />
-		<xs:enumeration value="JPR" />
-		<xs:enumeration value="JRB" />
-		<xs:enumeration value="KAA" />
-		<xs:enumeration value="KAB" />
-		<xs:enumeration value="KAC" />
-		<xs:enumeration value="KAL" />
-		<xs:enumeration value="KAM" />
-		<xs:enumeration value="KAN" />
-		<xs:enumeration value="KAR" />
-		<xs:enumeration value="KAS" />
-		<xs:enumeration value="KAU" />
-		<xs:enumeration value="KAW" />
-		<xs:enumeration value="KAZ" />
-		<xs:enumeration value="KBD" />
-		<xs:enumeration value="KHA" />
-		<xs:enumeration value="KHI" />
-		<xs:enumeration value="KHM" />
-		<xs:enumeration value="KHO" />
-		<xs:enumeration value="KIK" />
-		<xs:enumeration value="KIN" />
-		<xs:enumeration value="KIR" />
-		<xs:enumeration value="KMB" />
-		<xs:enumeration value="KOK" />
-		<xs:enumeration value="KOM" />
-		<xs:enumeration value="KON" />
-		<xs:enumeration value="KOR" />
-		<xs:enumeration value="KOS" />
-		<xs:enumeration value="KPE" />
-		<xs:enumeration value="KRC" />
-		<xs:enumeration value="KRL" />
-		<xs:enumeration value="KRO" />
-		<xs:enumeration value="KRU" />
-		<xs:enumeration value="KUA" />
-		<xs:enumeration value="KUM" />
-		<xs:enumeration value="KUR" />
-		<xs:enumeration value="KUT" />
-		<xs:enumeration value="LAD" />
-		<xs:enumeration value="LAH" />
-		<xs:enumeration value="LAM" />
-		<xs:enumeration value="LAO" />
-		<xs:enumeration value="LAT" />
-		<xs:enumeration value="LAV" />
-		<xs:enumeration value="LEZ" />
-		<xs:enumeration value="LIM" />
-		<xs:enumeration value="LIN" />
-		<xs:enumeration value="LIT" />
-		<xs:enumeration value="LOL" />
-		<xs:enumeration value="LOZ" />
-		<xs:enumeration value="LTZ" />
-		<xs:enumeration value="LUA" />
-		<xs:enumeration value="LUB" />
-		<xs:enumeration value="LUG" />
-		<xs:enumeration value="LUI" />
-		<xs:enumeration value="LUN" />
-		<xs:enumeration value="LUO" />
-		<xs:enumeration value="LUS" />
-		<xs:enumeration value="MKD" />
-		<xs:enumeration value="MAD" />
-		<xs:enumeration value="MAG" />
-		<xs:enumeration value="MAH" />
-		<xs:enumeration value="MAI" />
-		<xs:enumeration value="MAK" />
-		<xs:enumeration value="MAL" />
-		<xs:enumeration value="MAN" />
-		<xs:enumeration value="MRI" />
-		<xs:enumeration value="MAP" />
-		<xs:enumeration value="MAR" />
-		<xs:enumeration value="MAS" />
-		<xs:enumeration value="MSA" />
-		<xs:enumeration value="MDF" />
-		<xs:enumeration value="MDR" />
-		<xs:enumeration value="MEN" />
-		<xs:enumeration value="MGA" />
-		<xs:enumeration value="MIC" />
-		<xs:enumeration value="MIN" />
-		<xs:enumeration value="MKH" />
-		<xs:enumeration value="MLG" />
-		<xs:enumeration value="MLT" />
-		<xs:enumeration value="MNC" />
-		<xs:enumeration value="MNI" />
-		<xs:enumeration value="MNO" />
-		<xs:enumeration value="MOH" />
-		<xs:enumeration value="MON" />
-		<xs:enumeration value="MOS" />
-		<xs:enumeration value="MUN" />
-		<xs:enumeration value="MUS" />
-		<xs:enumeration value="MWL" />
-		<xs:enumeration value="MWR" />
-		<xs:enumeration value="MYN" />
-		<xs:enumeration value="MYV" />
-		<xs:enumeration value="NAH" />
-		<xs:enumeration value="NAI" />
-		<xs:enumeration value="NAP" />
-		<xs:enumeration value="NAU" />
-		<xs:enumeration value="NAV" />
-		<xs:enumeration value="NBL" />
-		<xs:enumeration value="NDE" />
-		<xs:enumeration value="NDO" />
-		<xs:enumeration value="NDS" />
-		<xs:enumeration value="NEP" />
-		<xs:enumeration value="NEW" />
-		<xs:enumeration value="NIA" />
-		<xs:enumeration value="NIC" />
-		<xs:enumeration value="NIU" />
-		<xs:enumeration value="NNO" />
-		<xs:enumeration value="NOB" />
-		<xs:enumeration value="NOG" />
-		<xs:enumeration value="NON" />
-		<xs:enumeration value="NOR" />
-		<xs:enumeration value="NQO" />
-		<xs:enumeration value="NSO" />
-		<xs:enumeration value="NUB" />
-		<xs:enumeration value="NWC" />
-		<xs:enumeration value="NYA" />
-		<xs:enumeration value="NYM" />
-		<xs:enumeration value="NYN" />
-		<xs:enumeration value="NYO" />
-		<xs:enumeration value="NZI" />
-		<xs:enumeration value="OCI" />
-		<xs:enumeration value="OJI" />
-		<xs:enumeration value="ORI" />
-		<xs:enumeration value="ORM" />
-		<xs:enumeration value="OSA" />
-		<xs:enumeration value="OSS" />
-		<xs:enumeration value="OTA" />
-		<xs:enumeration value="OTO" />
-		<xs:enumeration value="PAA" />
-		<xs:enumeration value="PAG" />
-		<xs:enumeration value="PAL" />
-		<xs:enumeration value="PAM" />
-		<xs:enumeration value="PAN" />
-		<xs:enumeration value="PAP" />
-		<xs:enumeration value="PAU" />
-		<xs:enumeration value="PEO" />
-		<xs:enumeration value="FAS" />
-		<xs:enumeration value="PHI" />
-		<xs:enumeration value="PHN" />
-		<xs:enumeration value="PLI" />
-		<xs:enumeration value="POL" />
-		<xs:enumeration value="PON" />
-		<xs:enumeration value="POR" />
-		<xs:enumeration value="PRA" />
-		<xs:enumeration value="PRO" />
-		<xs:enumeration value="PUS" />
-		<xs:enumeration value="QUE" />
-		<xs:enumeration value="RAJ" />
-		<xs:enumeration value="RAP" />
-		<xs:enumeration value="RAR" />
-		<xs:enumeration value="ROA" />
-		<xs:enumeration value="ROH" />
-		<xs:enumeration value="ROM" />
-		<xs:enumeration value="RON" />
-		<xs:enumeration value="RUN" />
-		<xs:enumeration value="RUP" />
-		<xs:enumeration value="RUS" />
-		<xs:enumeration value="SAD" />
-		<xs:enumeration value="SAG" />
-		<xs:enumeration value="SAH" />
-		<xs:enumeration value="SAI" />
-		<xs:enumeration value="SAL" />
-		<xs:enumeration value="SAM" />
-		<xs:enumeration value="SAN" />
-		<xs:enumeration value="SAS" />
-		<xs:enumeration value="SAT" />
-		<xs:enumeration value="SCN" />
-		<xs:enumeration value="SCO" />
-		<xs:enumeration value="SEL" />
-		<xs:enumeration value="SEM" />
-		<xs:enumeration value="SGA" />
-		<xs:enumeration value="SGN" />
-		<xs:enumeration value="SHN" />
-		<xs:enumeration value="SID" />
-		<xs:enumeration value="SIN" />
-		<xs:enumeration value="SIO" />
-		<xs:enumeration value="SIT" />
-		<xs:enumeration value="SLA" />
-		<xs:enumeration value="SLK" />
-		<xs:enumeration value="SLV" />
-		<xs:enumeration value="SMA" />
-		<xs:enumeration value="SME" />
-		<xs:enumeration value="SMI" />
-		<xs:enumeration value="SMJ" />
-		<xs:enumeration value="SMN" />
-		<xs:enumeration value="SMO" />
-		<xs:enumeration value="SMS" />
-		<xs:enumeration value="SNA" />
-		<xs:enumeration value="SND" />
-		<xs:enumeration value="SNK" />
-		<xs:enumeration value="SOG" />
-		<xs:enumeration value="SOM" />
-		<xs:enumeration value="SON" />
-		<xs:enumeration value="SOT" />
-		<xs:enumeration value="SPA" />
-		<xs:enumeration value="SRD" />
-		<xs:enumeration value="SRN" />
-		<xs:enumeration value="SRP" />
-		<xs:enumeration value="SRR" />
-		<xs:enumeration value="SSA" />
-		<xs:enumeration value="SSW" />
-		<xs:enumeration value="SUK" />
-		<xs:enumeration value="SUN" />
-		<xs:enumeration value="SUS" />
-		<xs:enumeration value="SUX" />
-		<xs:enumeration value="SWA" />
-		<xs:enumeration value="SWE" />
-		<xs:enumeration value="SYC" />
-		<xs:enumeration value="SYR" />
-		<xs:enumeration value="TAH" />
-		<xs:enumeration value="TAI" />
-		<xs:enumeration value="TAM" />
-		<xs:enumeration value="TAT" />
-		<xs:enumeration value="TEL" />
-		<xs:enumeration value="TEM" />
-		<xs:enumeration value="TER" />
-		<xs:enumeration value="TET" />
-		<xs:enumeration value="TGK" />
-		<xs:enumeration value="TGL" />
-		<xs:enumeration value="THA" />
-		<xs:enumeration value="BOD" />
-		<xs:enumeration value="TIG" />
-		<xs:enumeration value="TIR" />
-		<xs:enumeration value="TIV" />
-		<xs:enumeration value="TKL" />
-		<xs:enumeration value="TLH" />
-		<xs:enumeration value="TLI" />
-		<xs:enumeration value="TMH" />
-		<xs:enumeration value="TOG" />
-		<xs:enumeration value="TON" />
-		<xs:enumeration value="TPI" />
-		<xs:enumeration value="TSI" />
-		<xs:enumeration value="TSN" />
-		<xs:enumeration value="TSO" />
-		<xs:enumeration value="TUK" />
-		<xs:enumeration value="TUM" />
-		<xs:enumeration value="TUP" />
-		<xs:enumeration value="TUR" />
-		<xs:enumeration value="TUT" />
-		<xs:enumeration value="TVL" />
-		<xs:enumeration value="TWI" />
-		<xs:enumeration value="TYV" />
-		<xs:enumeration value="UDM" />
-		<xs:enumeration value="UGA" />
-		<xs:enumeration value="UIG" />
-		<xs:enumeration value="UKR" />
-		<xs:enumeration value="UMB" />
-		<xs:enumeration value="URD" />
-		<xs:enumeration value="UZB" />
-		<xs:enumeration value="VAI" />
-		<xs:enumeration value="VEN" />
-		<xs:enumeration value="VIE" />
-		<xs:enumeration value="VOL" />
-		<xs:enumeration value="VOT" />
-		<xs:enumeration value="WAK" />
-		<xs:enumeration value="WAL" />
-		<xs:enumeration value="WAR" />
-		<xs:enumeration value="WAS" />
-		<xs:enumeration value="CYM" />
-		<xs:enumeration value="WEN" />
-		<xs:enumeration value="WLN" />
-		<xs:enumeration value="WOL" />
-		<xs:enumeration value="XAL" />
-		<xs:enumeration value="XHO" />
-		<xs:enumeration value="YAO" />
-		<xs:enumeration value="YAP" />
-		<xs:enumeration value="YID" />
-		<xs:enumeration value="YOR" />
-		<xs:enumeration value="YPK" />
-		<xs:enumeration value="ZAP" />
-		<xs:enumeration value="ZBL" />
-		<xs:enumeration value="ZEN" />
-		<xs:enumeration value="ZHA" />
-		<xs:enumeration value="ZND" />
-		<xs:enumeration value="ZUL" />
-		<xs:enumeration value="ZUN" />
-		<xs:enumeration value="ZZA" />
-		<xs:enumeration value="MIS" />
-		<xs:enumeration value="MUL" />
-		<xs:enumeration value="UND" />
-		<xs:enumeration value="ZXX" />
-	</xs:restriction>
-</xs:simpleType>
-<xs:simpleType name="languageIso1Type" id="languageIso1Type">
-	<xs:annotation>
-		<xs:documentation>Two-letter ISO 639-1 language code.</xs:documentation>
-	</xs:annotation>
-	<xs:enumeration value="AB" />
-	<xs:enumeration value="AA" />
-	<xs:enumeration value="AF" />
-	<xs:enumeration value="AK" />
-	<xs:enumeration value="SQ" />
-	<xs:enumeration value="AM" />
-	<xs:enumeration value="AR" />
-	<xs:enumeration value="AN" />
-	<xs:enumeration value="HY" />
-	<xs:enumeration value="AS" />
-	<xs:enumeration value="AV" />
-	<xs:enumeration value="AE" />
-	<xs:enumeration value="AY" />
-	<xs:enumeration value="AZ" />
-	<xs:enumeration value="BM" />
-	<xs:enumeration value="BA" />
-	<xs:enumeration value="EU" />
-	<xs:enumeration value="BE" />
-	<xs:enumeration value="BN" />
-	<xs:enumeration value="BI" />
-	<xs:enumeration value="BS" />
-	<xs:enumeration value="BR" />
-	<xs:enumeration value="BG" />
-	<xs:enumeration value="MY" />
-	<xs:enumeration value="CA" />
-	<xs:enumeration value="CH" />
-	<xs:enumeration value="CE" />
-	<xs:enumeration value="NY" />
-	<xs:enumeration value="ZH" />
-	<xs:enumeration value="CU" />
-	<xs:enumeration value="CV" />
-	<xs:enumeration value="KW" />
-	<xs:enumeration value="CO" />
-	<xs:enumeration value="CR" />
-	<xs:enumeration value="HR" />
-	<xs:enumeration value="CS" />
-	<xs:enumeration value="DA" />
-	<xs:enumeration value="DV" />
-	<xs:enumeration value="NL" />
-	<xs:enumeration value="DZ" />
-	<xs:enumeration value="EN" />
-	<xs:enumeration value="EO" />
-	<xs:enumeration value="ET" />
-	<xs:enumeration value="EE" />
-	<xs:enumeration value="FO" />
-	<xs:enumeration value="FJ" />
-	<xs:enumeration value="FI" />
-	<xs:enumeration value="FR" />
-	<xs:enumeration value="FY" />
-	<xs:enumeration value="FF" />
-	<xs:enumeration value="GD" />
-	<xs:enumeration value="GL" />
-	<xs:enumeration value="LG" />
-	<xs:enumeration value="KA" />
-	<xs:enumeration value="DE" />
-	<xs:enumeration value="EL" />
-	<xs:enumeration value="KL" />
-	<xs:enumeration value="GN" />
-	<xs:enumeration value="GU" />
-	<xs:enumeration value="HT" />
-	<xs:enumeration value="HA" />
-	<xs:enumeration value="HE" />
-	<xs:enumeration value="HZ" />
-	<xs:enumeration value="HI" />
-	<xs:enumeration value="HO" />
-	<xs:enumeration value="HU" />
-	<xs:enumeration value="IS" />
-	<xs:enumeration value="IO" />
-	<xs:enumeration value="IG" />
-	<xs:enumeration value="ID" />
-	<xs:enumeration value="IA" />
-	<xs:enumeration value="IE" />
-	<xs:enumeration value="IU" />
-	<xs:enumeration value="IK" />
-	<xs:enumeration value="GA" />
-	<xs:enumeration value="IT" />
-	<xs:enumeration value="JA" />
-	<xs:enumeration value="JV" />
-	<xs:enumeration value="KN" />
-	<xs:enumeration value="KR" />
-	<xs:enumeration value="KS" />
-	<xs:enumeration value="KK" />
-	<xs:enumeration value="KM" />
-	<xs:enumeration value="KI" />
-	<xs:enumeration value="RW" />
-	<xs:enumeration value="KY" />
-	<xs:enumeration value="KV" />
-	<xs:enumeration value="KG" />
-	<xs:enumeration value="KO" />
-	<xs:enumeration value="KJ" />
-	<xs:enumeration value="KU" />
-	<xs:enumeration value="LO" />
-	<xs:enumeration value="LA" />
-	<xs:enumeration value="LV" />
-	<xs:enumeration value="LI" />
-	<xs:enumeration value="LN" />
-	<xs:enumeration value="LT" />
-	<xs:enumeration value="LU" />
-	<xs:enumeration value="LB" />
-	<xs:enumeration value="MK" />
-	<xs:enumeration value="MG" />
-	<xs:enumeration value="MS" />
-	<xs:enumeration value="ML" />
-	<xs:enumeration value="MT" />
-	<xs:enumeration value="GV" />
-	<xs:enumeration value="MI" />
-	<xs:enumeration value="MR" />
-	<xs:enumeration value="MH" />
-	<xs:enumeration value="MN" />
-	<xs:enumeration value="NA" />
-	<xs:enumeration value="NV" />
-	<xs:enumeration value="ND" />
-	<xs:enumeration value="NR" />
-	<xs:enumeration value="NG" />
-	<xs:enumeration value="NE" />
-	<xs:enumeration value="NO" />
-	<xs:enumeration value="NB" />
-	<xs:enumeration value="NN" />
-	<xs:enumeration value="II" />
-	<xs:enumeration value="OC" />
-	<xs:enumeration value="OJ" />
-	<xs:enumeration value="OR" />
-	<xs:enumeration value="OM" />
-	<xs:enumeration value="OS" />
-	<xs:enumeration value="PI" />
-	<xs:enumeration value="PS" />
-	<xs:enumeration value="FA" />
-	<xs:enumeration value="PL" />
-	<xs:enumeration value="PT" />
-	<xs:enumeration value="PA" />
-	<xs:enumeration value="QU" />
-	<xs:enumeration value="RO" />
-	<xs:enumeration value="RM" />
-	<xs:enumeration value="RN" />
-	<xs:enumeration value="RU" />
-	<xs:enumeration value="SE" />
-	<xs:enumeration value="SM" />
-	<xs:enumeration value="SG" />
-	<xs:enumeration value="SA" />
-	<xs:enumeration value="SC" />
-	<xs:enumeration value="SR" />
-	<xs:enumeration value="SN" />
-	<xs:enumeration value="SD" />
-	<xs:enumeration value="SI" />
-	<xs:enumeration value="SK" />
-	<xs:enumeration value="SL" />
-	<xs:enumeration value="SO" />
-	<xs:enumeration value="ST" />
-	<xs:enumeration value="ES" />
-	<xs:enumeration value="SU" />
-	<xs:enumeration value="SW" />
-	<xs:enumeration value="SS" />
-	<xs:enumeration value="SV" />
-	<xs:enumeration value="TL" />
-	<xs:enumeration value="TY" />
-	<xs:enumeration value="TG" />
-	<xs:enumeration value="TA" />
-	<xs:enumeration value="TT" />
-	<xs:enumeration value="TE" />
-	<xs:enumeration value="TH" />
-	<xs:enumeration value="BO" />
-	<xs:enumeration value="TI" />
-	<xs:enumeration value="TO" />
-	<xs:enumeration value="TS" />
-	<xs:enumeration value="TN" />
-	<xs:enumeration value="TR" />
-	<xs:enumeration value="TK" />
-	<xs:enumeration value="TW" />
-	<xs:enumeration value="UG" />
-	<xs:enumeration value="UK" />
-	<xs:enumeration value="UR" />
-	<xs:enumeration value="UZ" />
-	<xs:enumeration value="VE" />
-	<xs:enumeration value="VI" />
-	<xs:enumeration value="VO" />
-	<xs:enumeration value="WA" />
-	<xs:enumeration value="CY" />
-	<xs:enumeration value="WO" />
-	<xs:enumeration value="XH" />
-	<xs:enumeration value="YI" />
-	<xs:enumeration value="YO" />
-	<xs:enumeration value="ZA" />
-	<xs:enumeration value="ZU" />
-</xs:restriction>
-</xs:simpleType>
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified">
+  <xs:import schemaLocation="https://www.w3.org/1999/xlink.xsd" namespace="http://www.w3.org/1999/xlink"/>
+  <xs:element name="journal">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="journal-id">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="journal-id-type" type="xs:string" use="required"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="journal-title-group">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="journal-title" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element maxOccurs="unbounded" name="issn">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="publication-format" type="issnPublicationFormatType" use="required"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" name="publisher">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element minOccurs="0" name="publisher-name" type="xs:string"/>
+              <xs:element minOccurs="0" name="publisher-location">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="country">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="iso2" type="countryIso2Type" use="optional"/>
+                            <xs:attribute name="iso3" type="countryIso3Type" use="optional"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" name="publication-policy">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element minOccurs="0" name="costs">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element minOccurs="0" name="apc">
+                      <xs:complexType>
+                        <xs:attribute name="present" type="xs:boolean" use="required"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element minOccurs="0" name="other-charges">
+                      <xs:complexType>
+                        <xs:attribute name="present" type="xs:boolean" use="required"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element minOccurs="0" name="review-process">
+                <xs:complexType>
+                  <xs:attribute name="peer-review" type="xs:boolean" use="required"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element minOccurs="0" name="languages">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element maxOccurs="unbounded" name="language">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="iso1" type="languageIso1Type" use="optional"/>
+                            <xs:attribute name="iso2" type="languageIso2Type" use="optional"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element minOccurs="0" name="licenses">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element maxOccurs="unbounded" name="license">
+                      <xs:complexType>
+                        <xs:attribute ref="xlink:href" use="required"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element minOccurs="0" name="authorship">
+                <xs:complexType>
+                  <xs:attribute name="open" type="xs:boolean" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" name="self-uri">
+          <xs:complexType>
+            <xs:attribute ref="xlink:href" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="kwd-group">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element minOccurs="0" name="compound-kwd">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element maxOccurs="unbounded" name="compound-kwd-part">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="content-type" type="xs:string" use="required"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="unbounded" name="kwd" type="xs:string"/>
+            </xs:sequence>
+            <xs:attribute name="vocab" type="xs:string" use="optional"/>
+            <xs:attribute name="vocab-identifier" type="xs:string" use="optional"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="owner-type" type="journalOwnerType" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="journalOwnerType" id="journalOwnerType">
+    <xs:annotation>
+      <xs:documentation>Type of owner of journal.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="scholar"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="issnPublicationFormatType" id="issnPublicationFormatType">
+    <xs:annotation>
+      <xs:documentation>Publication format for the ISSN.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="print"/>
+      <xs:enumeration value="electronic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="countryIso2Type" id="countryIso2Type">
+    <xs:annotation>
+      <xs:documentation>Two-letter ISO 3166-1 alpha-2 country code.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <!-- Andorra -->
+      <xs:enumeration value="AD"/>
+      <!-- United Arab Emirates -->
+      <xs:enumeration value="AE"/>
+      <!-- Afghanistan -->
+      <xs:enumeration value="AF"/>
+      <!-- Antigua and Barbuda -->
+      <xs:enumeration value="AG"/>
+      <!-- Anguilla -->
+      <xs:enumeration value="AI"/>
+      <!-- Albania -->
+      <xs:enumeration value="AL"/>
+      <!-- Armenia -->
+      <xs:enumeration value="AM"/>
+      <!-- Angola -->
+      <xs:enumeration value="AO"/>
+      <!-- Antarctica -->
+      <xs:enumeration value="AQ"/>
+      <!-- Argentina -->
+      <xs:enumeration value="AR"/>
+      <!-- American Samoa -->
+      <xs:enumeration value="AS"/>
+      <!-- Austria -->
+      <xs:enumeration value="AT"/>
+      <!-- Australia -->
+      <xs:enumeration value="AU"/>
+      <!-- Aruba -->
+      <xs:enumeration value="AW"/>
+      <!-- Åland Islands (An autonomous county of Finland) -->
+      <xs:enumeration value="AX"/>
+      <!-- Azerbaijan -->
+      <xs:enumeration value="AZ"/>
+      <!-- Bosnia and Herzegovina -->
+      <xs:enumeration value="BA"/>
+      <!-- Barbados -->
+      <xs:enumeration value="BB"/>
+      <!-- Bangladesh -->
+      <xs:enumeration value="BD"/>
+      <!-- Belgium -->
+      <xs:enumeration value="BE"/>
+      <!-- Burkina Faso -->
+      <xs:enumeration value="BF"/>
+      <!-- Bulgaria -->
+      <xs:enumeration value="BG"/>
+      <!-- Bahrain -->
+      <xs:enumeration value="BH"/>
+      <!-- Burundi -->
+      <xs:enumeration value="BI"/>
+      <!-- Benin -->
+      <xs:enumeration value="BJ"/>
+      <!-- Saint Barthélemy -->
+      <xs:enumeration value="BL"/>
+      <!-- Bermuda -->
+      <xs:enumeration value="BM"/>
+      <!-- Brunei Darussalam -->
+      <xs:enumeration value="BN"/>
+      <!-- Bolivia (Plurinational State of) -->
+      <xs:enumeration value="BO"/>
+      <!-- Bonaire, Sint Eustatius and Saba (Part of the Netherlands) -->
+      <xs:enumeration value="BQ"/>
+      <!-- Brazil -->
+      <xs:enumeration value="BR"/>
+      <!-- Bahamas -->
+      <xs:enumeration value="BS"/>
+      <!-- Bhutan -->
+      <xs:enumeration value="BT"/>
+      <!-- Bouvet Island (Dependency of Norway) -->
+      <xs:enumeration value="BV"/>
+      <!-- Botswana -->
+      <xs:enumeration value="BW"/>
+      <!-- Belarus -->
+      <xs:enumeration value="BY"/>
+      <!-- Belize -->
+      <xs:enumeration value="BZ"/>
+      <!-- Canada -->
+      <xs:enumeration value="CA"/>
+      <!-- Cocos (Keeling) Islands (External territory of Australia) -->
+      <xs:enumeration value="CC"/>
+      <!-- Congo, Democratic Republic of the -->
+      <xs:enumeration value="CD"/>
+      <!-- Central African Republic -->
+      <xs:enumeration value="CF"/>
+      <!-- Congo -->
+      <xs:enumeration value="CG"/>
+      <!-- Switzerland -->
+      <xs:enumeration value="CH"/>
+      <!-- Côte d'Ivoire -->
+      <xs:enumeration value="CI"/>
+      <!-- Cook Islands -->
+      <xs:enumeration value="CK"/>
+      <!-- Chile  -->
+      <xs:enumeration value="CL"/>
+      <!-- Cameroon -->
+      <xs:enumeration value="CM"/>
+      <!-- China -->
+      <xs:enumeration value="CN"/>
+      <!-- Colombia -->
+      <xs:enumeration value="CO"/>
+      <!-- Costa Rica -->
+      <xs:enumeration value="CR"/>
+      <!-- Cuba -->
+      <xs:enumeration value="CU"/>
+      <!-- Cabo Verde -->
+      <xs:enumeration value="CV"/>
+      <!-- Curaçao -->
+      <xs:enumeration value="CW"/>
+      <!-- Christmas Island -->
+      <xs:enumeration value="CX"/>
+      <!-- Cyprus -->
+      <xs:enumeration value="CY"/>
+      <!-- Czechia -->
+      <xs:enumeration value="CZ"/>
+      <!-- Germany -->
+      <xs:enumeration value="DE"/>
+      <!-- Djibouti -->
+      <xs:enumeration value="DJ"/>
+      <!-- Denmark -->
+      <xs:enumeration value="DK"/>
+      <!-- Dominica -->
+      <xs:enumeration value="DM"/>
+      <!-- Dominican Republic -->
+      <xs:enumeration value="DO"/>
+      <!-- Algeria -->
+      <xs:enumeration value="DZ"/>
+      <!-- Ecuador -->
+      <xs:enumeration value="EC"/>
+      <!-- Estonia -->
+      <xs:enumeration value="EE"/>
+      <!-- Egypt -->
+      <xs:enumeration value="EG"/>
+      <!-- Western Sahara -->
+      <xs:enumeration value="EH"/>
+      <!-- Eritrea -->
+      <xs:enumeration value="ER"/>
+      <!-- Spain -->
+      <xs:enumeration value="ES"/>
+      <!-- Ethiopia -->
+      <xs:enumeration value="ET"/>
+      <!-- Finland -->
+      <xs:enumeration value="FI"/>
+      <!-- Fiji -->
+      <xs:enumeration value="FJ"/>
+      <!-- Falkland Islands (Malvinas) -->
+      <xs:enumeration value="FK"/>
+      <!-- Micronesia (Federated States of) -->
+      <xs:enumeration value="FM"/>
+      <!-- Faroe Islands -->
+      <xs:enumeration value="FO"/>
+      <!-- France -->
+      <xs:enumeration value="FR"/>
+      <!-- Gabon -->
+      <xs:enumeration value="GA"/>
+      <!-- United Kingdom of Great Britain and Northern Ireland -->
+      <xs:enumeration value="GB"/>
+      <!-- Grenada -->
+      <xs:enumeration value="GD"/>
+      <!-- Georgia -->
+      <xs:enumeration value="GE"/>
+      <!-- French Guiana -->
+      <xs:enumeration value="GF"/>
+      <!-- Guernsey (A British Crown Dependency) -->
+      <xs:enumeration value="GG"/>
+      <!-- Ghana -->
+      <xs:enumeration value="GH"/>
+      <!-- Gibraltar -->
+      <xs:enumeration value="GI"/>
+      <!-- Greenland -->
+      <xs:enumeration value="GL"/>
+      <!-- Gambia -->
+      <xs:enumeration value="GM"/>
+      <!-- Guinea -->
+      <xs:enumeration value="GN"/>
+      <!-- Guadeloupe -->
+      <xs:enumeration value="GP"/>
+      <!-- Equatorial Guinea -->
+      <xs:enumeration value="GQ"/>
+      <!-- Greece -->
+      <xs:enumeration value="GR"/>
+      <!-- South Georgia and the South Sandwich Islands -->
+      <xs:enumeration value="GS"/>
+      <!-- Guatemala -->
+      <xs:enumeration value="GT"/>
+      <!-- Guam -->
+      <xs:enumeration value="GU"/>
+      <!-- Guinea-Bissau -->
+      <xs:enumeration value="GW"/>
+      <!-- Guyana  -->
+      <xs:enumeration value="GY"/>
+      <!-- Hong Kong -->
+      <xs:enumeration value="HK"/>
+      <!-- Heard Island and McDonald Islands (External territory of Australia) -->
+      <xs:enumeration value="HM"/>
+      <!-- Honduras -->
+      <xs:enumeration value="HN"/>
+      <!-- Croatia -->
+      <xs:enumeration value="HR"/>
+      <!-- Haiti -->
+      <xs:enumeration value="HT"/>
+      <!-- Hungary  -->
+      <xs:enumeration value="HU"/>
+      <!-- Indonesia -->
+      <xs:enumeration value="ID"/>
+      <!-- Ireland -->
+      <xs:enumeration value="IE"/>
+      <!-- Israel -->
+      <xs:enumeration value="IL"/>
+      <!-- Isle of Man (A British Crown Dependency) -->
+      <xs:enumeration value="IM"/>
+      <!-- India -->
+      <xs:enumeration value="IN"/>
+      <!-- British Indian Ocean Territory -->
+      <xs:enumeration value="IO"/>
+      <!-- Iraq -->
+      <xs:enumeration value="IQ"/>
+      <!-- Iran (Islamic Republic of) -->
+      <xs:enumeration value="IR"/>
+      <!-- Iceland -->
+      <xs:enumeration value="IS"/>
+      <!-- Italy -->
+      <xs:enumeration value="IT"/>
+      <!-- Jersey (A British Crown Dependency) -->
+      <xs:enumeration value="JE"/>
+      <!-- Jamaica -->
+      <xs:enumeration value="JM"/>
+      <!-- Jordan  -->
+      <xs:enumeration value="JO"/>
+      <!-- Japan -->
+      <xs:enumeration value="JP"/>
+      <!-- Kenya -->
+      <xs:enumeration value="KE"/>
+      <!-- Kyrgyzstan -->
+      <xs:enumeration value="KG"/>
+      <!-- Cambodia -->
+      <xs:enumeration value="KH"/>
+      <!-- Kiribati -->
+      <xs:enumeration value="KI"/>
+      <!-- Comoros -->
+      <xs:enumeration value="KM"/>
+      <!-- Saint Kitts and Nevis -->
+      <xs:enumeration value="KN"/>
+      <!-- Korea (Democratic People's Republic of) (common name: North Korea) -->
+      <xs:enumeration value="KP"/>
+      <!-- Korea, Republic of (common name: South Korea) -->
+      <xs:enumeration value="KR"/>
+      <!-- Kuwait -->
+      <xs:enumeration value="KW"/>
+      <!-- Cayman Islands -->
+      <xs:enumeration value="KY"/>
+      <!-- Kazakhstan -->
+      <xs:enumeration value="KZ"/>
+      <!-- Lao People's Democratic Republic -->
+      <xs:enumeration value="LA"/>
+      <!-- Lebanon -->
+      <xs:enumeration value="LB"/>
+      <!-- Saint Lucia -->
+      <xs:enumeration value="LC"/>
+      <!-- Liechtenstein -->
+      <xs:enumeration value="LI"/>
+      <!-- Sri Lanka  -->
+      <xs:enumeration value="LK"/>
+      <!-- Liberia -->
+      <xs:enumeration value="LR"/>
+      <!-- Lesotho -->
+      <xs:enumeration value="LS"/>
+      <!-- Lithuania  -->
+      <xs:enumeration value="LT"/>
+      <!-- Luxembourg -->
+      <xs:enumeration value="LU"/>
+      <!-- Latvia -->
+      <xs:enumeration value="LV"/>
+      <!-- Libya -->
+      <xs:enumeration value="LY"/>
+      <!-- Morocco -->
+      <xs:enumeration value="MA"/>
+      <!-- Monaco -->
+      <xs:enumeration value="MC"/>
+      <!-- Moldova, Republic of -->
+      <xs:enumeration value="MD"/>
+      <!-- Montenegro -->
+      <xs:enumeration value="ME"/>
+      <!-- Saint Martin (French part) -->
+      <xs:enumeration value="MF"/>
+      <!-- Madagascar -->
+      <xs:enumeration value="MG"/>
+      <!-- Marshall Islands -->
+      <xs:enumeration value="MH"/>
+      <!-- North Macedonia -->
+      <xs:enumeration value="MK"/>
+      <!-- Mali -->
+      <xs:enumeration value="ML"/>
+      <!-- Myanmar -->
+      <xs:enumeration value="MM"/>
+      <!-- Mongolia -->
+      <xs:enumeration value="MN"/>
+      <!-- Macao -->
+      <xs:enumeration value="MO"/>
+      <!-- Northern Mariana Islands -->
+      <xs:enumeration value="MP"/>
+      <!-- Martinique -->
+      <xs:enumeration value="MQ"/>
+      <!-- Mauritania -->
+      <xs:enumeration value="MR"/>
+      <!-- Montserrat -->
+      <xs:enumeration value="MS"/>
+      <!-- Malta -->
+      <xs:enumeration value="MT"/>
+      <!-- Mauritius -->
+      <xs:enumeration value="MU"/>
+      <!-- Maldives -->
+      <xs:enumeration value="MV"/>
+      <!-- Malawi -->
+      <xs:enumeration value="MW"/>
+      <!-- Mexico -->
+      <xs:enumeration value="MX"/>
+      <!-- Malaysia -->
+      <xs:enumeration value="MY"/>
+      <!-- Mozambique -->
+      <xs:enumeration value="MZ"/>
+      <!-- Namibia -->
+      <xs:enumeration value="NA"/>
+      <!-- New Caledonia -->
+      <xs:enumeration value="NC"/>
+      <!-- Niger -->
+      <xs:enumeration value="NE"/>
+      <!-- Norfolk Island (External territory of Australia) -->
+      <xs:enumeration value="NF"/>
+      <!-- Nigeria -->
+      <xs:enumeration value="NG"/>
+      <!-- Nicaragua -->
+      <xs:enumeration value="NI"/>
+      <!-- Netherlands, Kingdom of the -->
+      <xs:enumeration value="NL"/>
+      <!-- Norway -->
+      <xs:enumeration value="NO"/>
+      <!-- Nepal -->
+      <xs:enumeration value="NP"/>
+      <!-- Nauru -->
+      <xs:enumeration value="NR"/>
+      <!-- Niue -->
+      <xs:enumeration value="NU"/>
+      <!-- New Zealand -->
+      <xs:enumeration value="NZ"/>
+      <!-- Oman -->
+      <xs:enumeration value="OM"/>
+      <!-- Panama -->
+      <xs:enumeration value="PA"/>
+      <!-- Peru -->
+      <xs:enumeration value="PE"/>
+      <!-- French Polynesia -->
+      <xs:enumeration value="PF"/>
+      <!-- Papua New Guinea -->
+      <xs:enumeration value="PG"/>
+      <!-- Philippines -->
+      <xs:enumeration value="PH"/>
+      <!-- Pakistan -->
+      <xs:enumeration value="PK"/>
+      <!-- Poland -->
+      <xs:enumeration value="PL"/>
+      <!-- Saint Pierre and Miquelon -->
+      <xs:enumeration value="PM"/>
+      <!-- Pitcairn -->
+      <xs:enumeration value="PN"/>
+      <!-- Puerto Rico -->
+      <xs:enumeration value="PR"/>
+      <!-- Palestine, State of -->
+      <xs:enumeration value="PS"/>
+      <!-- Portugal -->
+      <xs:enumeration value="PT"/>
+      <!-- Palau -->
+      <xs:enumeration value="PW"/>
+      <!-- Paraguay -->
+      <xs:enumeration value="PY"/>
+      <!-- Qatar -->
+      <xs:enumeration value="QA"/>
+      <!-- Réunion -->
+      <xs:enumeration value="RE"/>
+      <!-- Romania -->
+      <xs:enumeration value="RO"/>
+      <!-- Serbia -->
+      <xs:enumeration value="RS"/>
+      <!-- Russian Federation -->
+      <xs:enumeration value="RU"/>
+      <!-- Rwanda -->
+      <xs:enumeration value="RW"/>
+      <!-- Saudi Arabia -->
+      <xs:enumeration value="SA"/>
+      <!-- Solomon Islands -->
+      <xs:enumeration value="SB"/>
+      <!-- Seychelles -->
+      <xs:enumeration value="SC"/>
+      <!-- Sudan -->
+      <xs:enumeration value="SD"/>
+      <!-- Sweden -->
+      <xs:enumeration value="SE"/>
+      <!-- Singapore -->
+      <xs:enumeration value="SG"/>
+      <!-- Saint Helena, Ascension and Tristan da Cunha -->
+      <xs:enumeration value="SH"/>
+      <!-- Slovenia -->
+      <xs:enumeration value="SI"/>
+      <!-- Svalbard and Jan Mayen -->
+      <xs:enumeration value="SJ"/>
+      <!-- Slovakia -->
+      <xs:enumeration value="SK"/>
+      <!-- Sierra Leone -->
+      <xs:enumeration value="SL"/>
+      <!-- San Marino -->
+      <xs:enumeration value="SM"/>
+      <!-- Senegal -->
+      <xs:enumeration value="SN"/>
+      <!-- Somalia -->
+      <xs:enumeration value="SO"/>
+      <!-- Suriname -->
+      <xs:enumeration value="SR"/>
+      <!-- South Sudan -->
+      <xs:enumeration value="SS"/>
+      <!-- Sao Tome and Principe -->
+      <xs:enumeration value="ST"/>
+      <!-- El Salvador -->
+      <xs:enumeration value="SV"/>
+      <!-- Sint Maarten (Dutch part) -->
+      <xs:enumeration value="SX"/>
+      <!-- Syrian Arab Republic -->
+      <xs:enumeration value="SY"/>
+      <!-- Eswatini -->
+      <xs:enumeration value="SZ"/>
+      <!-- Turks and Caicos Islands -->
+      <xs:enumeration value="TC"/>
+      <!-- Chad -->
+      <xs:enumeration value="TD"/>
+      <!-- French Southern Territories -->
+      <xs:enumeration value="TF"/>
+      <!-- Togo -->
+      <xs:enumeration value="TG"/>
+      <!-- Thailand -->
+      <xs:enumeration value="TH"/>
+      <!-- Tajikistan -->
+      <xs:enumeration value="TJ"/>
+      <!-- Tokelau -->
+      <xs:enumeration value="TK"/>
+      <!-- Timor-Leste -->
+      <xs:enumeration value="TL"/>
+      <!-- Turkmenistan -->
+      <xs:enumeration value="TM"/>
+      <!-- Tunisia -->
+      <xs:enumeration value="TN"/>
+      <!-- Tonga -->
+      <xs:enumeration value="TO"/>
+      <!-- Türkiye -->
+      <xs:enumeration value="TR"/>
+      <!-- Trinidad and Tobago -->
+      <xs:enumeration value="TT"/>
+      <!-- Tuvalu -->
+      <xs:enumeration value="TV"/>
+      <!-- Taiwan, Province of China -->
+      <xs:enumeration value="TW"/>
+      <!-- Tanzania, United Republic of -->
+      <xs:enumeration value="TZ"/>
+      <!-- Ukraine -->
+      <xs:enumeration value="UA"/>
+      <!-- Uganda -->
+      <xs:enumeration value="UG"/>
+      <!-- United States Minor Outlying Islands -->
+      <xs:enumeration value="UM"/>
+      <!-- United States of America -->
+      <xs:enumeration value="US"/>
+      <!-- Uruguay -->
+      <xs:enumeration value="UY"/>
+      <!-- Uzbekistan -->
+      <xs:enumeration value="UZ"/>
+      <!-- Holy See -->
+      <xs:enumeration value="VA"/>
+      <!-- Saint Vincent and the Grenadines -->
+      <xs:enumeration value="VC"/>
+      <!-- Venezuela (Bolivarian Republic of) -->
+      <xs:enumeration value="VE"/>
+      <!-- Virgin Islands (British) -->
+      <xs:enumeration value="VG"/>
+      <!-- Virgin Islands (U.S.) -->
+      <xs:enumeration value="VI"/>
+      <!-- Viet Nam -->
+      <xs:enumeration value="VN"/>
+      <!-- Vanuatu -->
+      <xs:enumeration value="VU"/>
+      <!-- Wallis and Futuna -->
+      <xs:enumeration value="WF"/>
+      <!-- Samoa -->
+      <xs:enumeration value="WS"/>
+      <!-- Yemen -->
+      <xs:enumeration value="YE"/>
+      <!-- Mayotte -->
+      <xs:enumeration value="YT"/>
+      <!-- South Africa -->
+      <xs:enumeration value="ZA"/>
+      <!-- Zambia -->
+      <xs:enumeration value="ZM"/>
+      <!-- Zimbabwe -->
+      <xs:enumeration value="ZW"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="countryIso3Type" id="countryIso3Type">
+    <xs:annotation>
+      <xs:documentation>Three-letter ISO 3166-1 alpha-3 country code.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ABW"/> <!-- Aruba -->
+      <xs:enumeration value="AFG"/> <!-- Afghanistan -->
+      <xs:enumeration value="AGO"/> <!-- Angola -->
+      <xs:enumeration value="AIA"/> <!-- Anguilla -->
+      <xs:enumeration value="ALA"/> <!-- Åland Islands -->
+      <xs:enumeration value="ALB"/> <!-- Albania -->
+      <xs:enumeration value="AND"/> <!-- Andorra -->
+      <xs:enumeration value="ARE"/> <!-- United Arab Emirates -->
+      <xs:enumeration value="ARG"/> <!-- Argentina -->
+      <xs:enumeration value="ARM"/> <!-- Armenia -->
+      <xs:enumeration value="ASM"/> <!-- American Samoa -->
+      <xs:enumeration value="ATA"/> <!-- Antarctica -->
+      <xs:enumeration value="ATF"/> <!-- French Southern Territories -->
+      <xs:enumeration value="ATG"/> <!-- Antigua and Barbuda -->
+      <xs:enumeration value="AUS"/> <!-- Australia -->
+      <xs:enumeration value="AUT"/> <!-- Austria -->
+      <xs:enumeration value="AZE"/> <!-- Azerbaijan -->
+      <xs:enumeration value="BDI"/> <!-- Burundi -->
+      <xs:enumeration value="BEL"/> <!-- Belgium -->
+      <xs:enumeration value="BEN"/> <!-- Benin -->
+      <xs:enumeration value="BES"/> <!-- Bonaire, Sint Eustatius and Saba -->
+      <xs:enumeration value="BFA"/> <!-- Burkina Faso -->
+      <xs:enumeration value="BGD"/> <!-- Bangladesh -->
+      <xs:enumeration value="BGR"/> <!-- Bulgaria -->
+      <xs:enumeration value="BHR"/> <!-- Bahrain -->
+      <xs:enumeration value="BHS"/> <!-- Bahamas -->
+      <xs:enumeration value="BIH"/> <!-- Bosnia and Herzegovina -->
+      <xs:enumeration value="BLM"/> <!-- Saint Barthélemy -->
+      <xs:enumeration value="BLR"/> <!-- Belarus -->
+      <xs:enumeration value="BLZ"/> <!-- Belize -->
+      <xs:enumeration value="BMU"/> <!-- Bermuda -->
+      <xs:enumeration value="BOL"/> <!-- Bolivia, Plurinational State of -->
+      <xs:enumeration value="BRA"/> <!-- Brazil -->
+      <xs:enumeration value="BRB"/> <!-- Barbados -->
+      <xs:enumeration value="BRN"/> <!-- Brunei Darussalam -->
+      <xs:enumeration value="BTN"/> <!-- Bhutan -->
+      <xs:enumeration value="BVT"/> <!-- Bouvet Island -->
+      <xs:enumeration value="BWA"/> <!-- Botswana -->
+      <xs:enumeration value="CAF"/> <!-- Central African Republic -->
+      <xs:enumeration value="CAN"/> <!-- Canada -->
+      <xs:enumeration value="CCK"/> <!-- Cocos (Keeling) Islands -->
+      <xs:enumeration value="CHE"/> <!-- Switzerland -->
+      <xs:enumeration value="CHL"/> <!-- Chile -->
+      <xs:enumeration value="CHN"/> <!-- China -->
+      <xs:enumeration value="CIV"/> <!-- Côte d'Ivoire -->
+      <xs:enumeration value="CMR"/> <!-- Cameroon -->
+      <xs:enumeration value="COD"/> <!-- Congo, Democratic Republic of the -->
+      <xs:enumeration value="COG"/> <!-- Congo -->
+      <xs:enumeration value="COK"/> <!-- Cook Islands -->
+      <xs:enumeration value="COL"/> <!-- Colombia -->
+      <xs:enumeration value="COM"/> <!-- Comoros -->
+      <xs:enumeration value="CPV"/> <!-- Cabo Verde -->
+      <xs:enumeration value="CRI"/> <!-- Costa Rica -->
+      <xs:enumeration value="CUB"/> <!-- Cuba -->
+      <xs:enumeration value="CUW"/> <!-- Curaçao -->
+      <xs:enumeration value="CXR"/> <!-- Christmas Island -->
+      <xs:enumeration value="CYM"/> <!-- Cayman Islands -->
+      <xs:enumeration value="CYP"/> <!-- Cyprus -->
+      <xs:enumeration value="CZE"/> <!-- Czechia -->
+      <xs:enumeration value="DEU"/> <!-- Germany -->
+      <xs:enumeration value="DJI"/> <!-- Djibouti -->
+      <xs:enumeration value="DMA"/> <!-- Dominica -->
+      <xs:enumeration value="DNK"/> <!-- Denmark -->
+      <xs:enumeration value="DOM"/> <!-- Dominican Republic -->
+      <xs:enumeration value="DZA"/> <!-- Algeria -->
+      <xs:enumeration value="ECU"/> <!-- Ecuador -->
+      <xs:enumeration value="EGY"/> <!-- Egypt -->
+      <xs:enumeration value="ERI"/> <!-- Eritrea -->
+      <xs:enumeration value="ESH"/> <!-- Western Sahara -->
+      <xs:enumeration value="ESP"/> <!-- Spain -->
+      <xs:enumeration value="EST"/> <!-- Estonia -->
+      <xs:enumeration value="ETH"/> <!-- Ethiopia -->
+      <xs:enumeration value="FIN"/> <!-- Finland -->
+      <xs:enumeration value="FJI"/> <!-- Fiji -->
+      <xs:enumeration value="FLK"/> <!-- Falkland Islands (Malvinas) -->
+      <xs:enumeration value="FRA"/> <!-- France -->
+      <xs:enumeration value="FRO"/> <!-- Faroe Islands -->
+      <xs:enumeration value="FSM"/> <!-- Micronesia, Federated States of -->
+      <xs:enumeration value="GAB"/> <!-- Gabon -->
+      <xs:enumeration value="GBR"/> <!-- United Kingdom of Great Britain and Northern Ireland -->
+      <xs:enumeration value="GEO"/> <!-- Georgia -->
+      <xs:enumeration value="GGY"/> <!-- Guernsey -->
+      <xs:enumeration value="GHA"/> <!-- Ghana -->
+      <xs:enumeration value="GIB"/> <!-- Gibraltar -->
+      <xs:enumeration value="GIN"/> <!-- Guinea -->
+      <xs:enumeration value="GLP"/> <!-- Guadeloupe -->
+      <xs:enumeration value="GMB"/> <!-- Gambia -->
+      <xs:enumeration value="GNB"/> <!-- Guinea-Bissau -->
+      <xs:enumeration value="GNQ"/> <!-- Equatorial Guinea -->
+      <xs:enumeration value="GRC"/> <!-- Greece -->
+      <xs:enumeration value="GRD"/> <!-- Grenada -->
+      <xs:enumeration value="GRL"/> <!-- Greenland -->
+      <xs:enumeration value="GTM"/> <!-- Guatemala -->
+      <xs:enumeration value="GUF"/> <!-- French Guiana -->
+      <xs:enumeration value="GUM"/> <!-- Guam -->
+      <xs:enumeration value="GUY"/> <!-- Guyana -->
+      <xs:enumeration value="HKG"/> <!-- Hong Kong -->
+      <xs:enumeration value="HMD"/> <!-- Heard Island and McDonald Islands -->
+      <xs:enumeration value="HND"/> <!-- Honduras -->
+      <xs:enumeration value="HRV"/> <!-- Croatia -->
+      <xs:enumeration value="HTI"/> <!-- Haiti -->
+      <xs:enumeration value="HUN"/> <!-- Hungary -->
+      <xs:enumeration value="IDN"/> <!-- Indonesia -->
+      <xs:enumeration value="IMN"/> <!-- Isle of Man -->
+      <xs:enumeration value="IND"/> <!-- India -->
+      <xs:enumeration value="IOT"/> <!-- British Indian Ocean Territory -->
+      <xs:enumeration value="IRL"/> <!-- Ireland -->
+      <xs:enumeration value="IRN"/> <!-- Iran, Islamic Republic of -->
+      <xs:enumeration value="IRQ"/> <!-- Iraq -->
+      <xs:enumeration value="ISL"/> <!-- Iceland -->
+      <xs:enumeration value="ISR"/> <!-- Israel -->
+      <xs:enumeration value="ITA"/> <!-- Italy -->
+      <xs:enumeration value="JAM"/> <!-- Jamaica -->
+      <xs:enumeration value="JEY"/> <!-- Jersey -->
+      <xs:enumeration value="JOR"/> <!-- Jordan -->
+      <xs:enumeration value="JPN"/> <!-- Japan -->
+      <xs:enumeration value="KAZ"/> <!-- Kazakhstan -->
+      <xs:enumeration value="KEN"/> <!-- Kenya -->
+      <xs:enumeration value="KGZ"/> <!-- Kyrgyzstan -->
+      <xs:enumeration value="KHM"/> <!-- Cambodia -->
+      <xs:enumeration value="KIR"/> <!-- Kiribati -->
+      <xs:enumeration value="KNA"/> <!-- Saint Kitts and Nevis -->
+      <xs:enumeration value="KOR"/> <!-- Korea, Republic of -->
+      <xs:enumeration value="KWT"/> <!-- Kuwait -->
+      <xs:enumeration value="LAO"/> <!-- Lao People's Democratic Republic -->
+      <xs:enumeration value="LBN"/> <!-- Lebanon -->
+      <xs:enumeration value="LBR"/> <!-- Liberia -->
+      <xs:enumeration value="LBY"/> <!-- Libya -->
+      <xs:enumeration value="LCA"/> <!-- Saint Lucia -->
+      <xs:enumeration value="LIE"/> <!-- Liechtenstein -->
+      <xs:enumeration value="LKA"/> <!-- Sri Lanka -->
+      <xs:enumeration value="LSO"/> <!-- Lesotho -->
+      <xs:enumeration value="LTU"/> <!-- Lithuania -->
+      <xs:enumeration value="LUX"/> <!-- Luxembourg -->
+      <xs:enumeration value="LVA"/> <!-- Latvia -->
+      <xs:enumeration value="MAC"/> <!-- Macao -->
+      <xs:enumeration value="MAF"/> <!-- Saint Martin (French part) -->
+      <xs:enumeration value="MAR"/> <!-- Morocco -->
+      <xs:enumeration value="MCO"/> <!-- Monaco -->
+      <xs:enumeration value="MDA"/> <!-- Moldova, Republic of -->
+      <xs:enumeration value="MDG"/> <!-- Madagascar -->
+      <xs:enumeration value="MDV"/> <!-- Maldives -->
+      <xs:enumeration value="MEX"/> <!-- Mexico -->
+      <xs:enumeration value="MHL"/> <!-- Marshall Islands -->
+      <xs:enumeration value="MKD"/> <!-- North Macedonia -->
+      <xs:enumeration value="MLI"/> <!-- Mali -->
+      <xs:enumeration value="MLT"/> <!-- Malta -->
+      <xs:enumeration value="MMR"/> <!-- Myanmar -->
+      <xs:enumeration value="MNE"/> <!-- Montenegro -->
+      <xs:enumeration value="MNG"/> <!-- Mongolia -->
+      <xs:enumeration value="MNP"/> <!-- Northern Mariana Islands -->
+      <xs:enumeration value="MOZ"/> <!-- Mozambique -->
+      <xs:enumeration value="MRT"/> <!-- Mauritania -->
+      <xs:enumeration value="MSR"/> <!-- Montserrat -->
+      <xs:enumeration value="MTQ"/> <!-- Martinique -->
+      <xs:enumeration value="MUS"/> <!-- Mauritius -->
+      <xs:enumeration value="MWI"/> <!-- Malawi -->
+      <xs:enumeration value="MYS"/> <!-- Malaysia -->
+      <xs:enumeration value="MYT"/> <!-- Mayotte -->
+      <xs:enumeration value="NAM"/> <!-- Namibia -->
+      <xs:enumeration value="NCL"/> <!-- New Caledonia -->
+      <xs:enumeration value="NER"/> <!-- Niger -->
+      <xs:enumeration value="NFK"/> <!-- Norfolk Island -->
+      <xs:enumeration value="NGA"/> <!-- Nigeria -->
+      <xs:enumeration value="NIC"/> <!-- Nicaragua -->
+      <xs:enumeration value="NIU"/> <!-- Niue -->
+      <xs:enumeration value="NLD"/> <!-- Netherlands, Kingdom of the -->
+      <xs:enumeration value="NOR"/> <!-- Norway -->
+      <xs:enumeration value="NPL"/> <!-- Nepal -->
+      <xs:enumeration value="NRU"/> <!-- Nauru -->
+      <xs:enumeration value="NZL"/> <!-- New Zealand -->
+      <xs:enumeration value="OMN"/> <!-- Oman -->
+      <xs:enumeration value="PAK"/> <!-- Pakistan -->
+      <xs:enumeration value="PAN"/> <!-- Panama -->
+      <xs:enumeration value="PCN"/> <!-- Pitcairn -->
+      <xs:enumeration value="PER"/> <!-- Peru -->
+      <xs:enumeration value="PHL"/> <!-- Philippines -->
+      <xs:enumeration value="PLW"/> <!-- Palau -->
+      <xs:enumeration value="PNG"/> <!-- Papua New Guinea -->
+      <xs:enumeration value="POL"/> <!-- Poland -->
+      <xs:enumeration value="PRI"/> <!-- Puerto Rico -->
+      <xs:enumeration value="PRK"/> <!-- Korea, Democratic People's Republic of -->
+      <xs:enumeration value="PRT"/> <!-- Portugal -->
+      <xs:enumeration value="PRY"/> <!-- Paraguay -->
+      <xs:enumeration value="PSE"/> <!-- Palestine, State of -->
+      <xs:enumeration value="PYF"/> <!-- French Polynesia -->
+      <xs:enumeration value="QAT"/> <!-- Qatar -->
+      <xs:enumeration value="REU"/> <!-- Réunion -->
+      <xs:enumeration value="ROU"/> <!-- Romania -->
+      <xs:enumeration value="RUS"/> <!-- Russian Federation -->
+      <xs:enumeration value="RWA"/> <!-- Rwanda -->
+      <xs:enumeration value="SAU"/> <!-- Saudi Arabia -->
+      <xs:enumeration value="SDN"/> <!-- Sudan -->
+      <xs:enumeration value="SEN"/> <!-- Senegal -->
+      <xs:enumeration value="SGP"/> <!-- Singapore -->
+      <xs:enumeration value="SGS"/> <!-- South Georgia and the South Sandwich Islands -->
+      <xs:enumeration value="SHN"/> <!-- Saint Helena, Ascension and Tristan da Cunha -->
+      <xs:enumeration value="SJM"/> <!-- Svalbard and Jan Mayen -->
+      <xs:enumeration value="SLB"/> <!-- Solomon Islands -->
+      <xs:enumeration value="SLE"/> <!-- Sierra Leone -->
+      <xs:enumeration value="SLV"/> <!-- El Salvador -->
+      <xs:enumeration value="SMR"/> <!-- San Marino -->
+      <xs:enumeration value="SOM"/> <!-- Somalia -->
+      <xs:enumeration value="SPM"/> <!-- Saint Pierre and Miquelon -->
+      <xs:enumeration value="SRB"/> <!-- Serbia -->
+      <xs:enumeration value="SSD"/> <!-- South Sudan -->
+      <xs:enumeration value="STP"/> <!-- Sao Tome and Principe -->
+      <xs:enumeration value="SUR"/> <!-- Suriname -->
+      <xs:enumeration value="SVK"/> <!-- Slovakia -->
+      <xs:enumeration value="SVN"/> <!-- Slovenia -->
+      <xs:enumeration value="SWE"/> <!-- Sweden -->
+      <xs:enumeration value="SWZ"/> <!-- Eswatini -->
+      <xs:enumeration value="SXM"/> <!-- Sint Maarten (Dutch part) -->
+      <xs:enumeration value="SYC"/> <!-- Seychelles -->
+      <xs:enumeration value="SYR"/> <!-- Syrian Arab Republic -->
+      <xs:enumeration value="TCA"/> <!-- Turks and Caicos Islands -->
+      <xs:enumeration value="TCD"/> <!-- Chad -->
+      <xs:enumeration value="TGO"/> <!-- Togo -->
+      <xs:enumeration value="THA"/> <!-- Thailand -->
+      <xs:enumeration value="TJK"/> <!-- Tajikistan -->
+      <xs:enumeration value="TKL"/> <!-- Tokelau -->
+      <xs:enumeration value="TKM"/> <!-- Turkmenistan -->
+      <xs:enumeration value="TLS"/> <!-- Timor-Leste -->
+      <xs:enumeration value="TON"/> <!-- Tonga -->
+      <xs:enumeration value="TTO"/> <!-- Trinidad and Tobago -->
+      <xs:enumeration value="TUN"/> <!-- Tunisia -->
+      <xs:enumeration value="TUR"/> <!-- Türkiye -->
+      <xs:enumeration value="TUV"/> <!-- Tuvalu -->
+      <xs:enumeration value="TWN"/> <!-- Taiwan, Province of China -->
+      <xs:enumeration value="TZA"/> <!-- Tanzania, United Republic of -->
+      <xs:enumeration value="UGA"/> <!-- Uganda -->
+      <xs:enumeration value="UKR"/> <!-- Ukraine -->
+      <xs:enumeration value="UMI"/> <!-- United States Minor Outlying Islands -->
+      <xs:enumeration value="URY"/> <!-- Uruguay -->
+      <xs:enumeration value="USA"/> <!-- United States of America -->
+      <xs:enumeration value="UZB"/> <!-- Uzbekistan -->
+      <xs:enumeration value="VAT"/> <!-- Holy See -->
+      <xs:enumeration value="VCT"/> <!-- Saint Vincent and the Grenadines -->
+      <xs:enumeration value="VEN"/> <!-- Venezuela, Bolivarian Republic of -->
+      <xs:enumeration value="VGB"/> <!-- Virgin Islands (British) -->
+      <xs:enumeration value="VIR"/> <!-- Virgin Islands (U.S.) -->
+      <xs:enumeration value="VNM"/> <!-- Viet Nam -->
+      <xs:enumeration value="VUT"/> <!-- Vanuatu -->
+      <xs:enumeration value="WLF"/> <!-- Wallis and Futuna -->
+      <xs:enumeration value="WSM"/> <!-- Samoa -->
+      <xs:enumeration value="YEM"/> <!-- Yemen -->
+      <xs:enumeration value="ZAF"/> <!-- South Africa -->
+      <xs:enumeration value="ZMB"/> <!-- Zambia -->
+      <xs:enumeration value="ZWE"/> <!-- Zimbabwe -->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="languageIso2Type" id="languageIso2Type">
+    <xs:annotation>
+      <xs:documentation>Three-letter ISO 639-2/T language code.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="AAR"/>
+      <xs:enumeration value="ABK"/>
+      <xs:enumeration value="ACE"/>
+      <xs:enumeration value="ACH"/>
+      <xs:enumeration value="ADA"/>
+      <xs:enumeration value="ADY"/>
+      <xs:enumeration value="AFA"/>
+      <xs:enumeration value="AFH"/>
+      <xs:enumeration value="AFR"/>
+      <xs:enumeration value="AIN"/>
+      <xs:enumeration value="AKA"/>
+      <xs:enumeration value="AKK"/>
+      <xs:enumeration value="SQI"/>
+      <xs:enumeration value="ALE"/>
+      <xs:enumeration value="ALG"/>
+      <xs:enumeration value="ALT"/>
+      <xs:enumeration value="AMH"/>
+      <xs:enumeration value="ANG"/>
+      <xs:enumeration value="ANP"/>
+      <xs:enumeration value="APA"/>
+      <xs:enumeration value="ARA"/>
+      <xs:enumeration value="ARC"/>
+      <xs:enumeration value="ARG"/>
+      <xs:enumeration value="HYE"/>
+      <xs:enumeration value="ARN"/>
+      <xs:enumeration value="ARP"/>
+      <xs:enumeration value="ART"/>
+      <xs:enumeration value="ARW"/>
+      <xs:enumeration value="ASM"/>
+      <xs:enumeration value="AST"/>
+      <xs:enumeration value="ATH"/>
+      <xs:enumeration value="AUS"/>
+      <xs:enumeration value="AVA"/>
+      <xs:enumeration value="AVE"/>
+      <xs:enumeration value="AWA"/>
+      <xs:enumeration value="AYM"/>
+      <xs:enumeration value="AZE"/>
+      <xs:enumeration value="BAD"/>
+      <xs:enumeration value="BAI"/>
+      <xs:enumeration value="BAK"/>
+      <xs:enumeration value="BAL"/>
+      <xs:enumeration value="BAM"/>
+      <xs:enumeration value="BAN"/>
+      <xs:enumeration value="EUS"/>
+      <xs:enumeration value="BAS"/>
+      <xs:enumeration value="BAT"/>
+      <xs:enumeration value="BEJ"/>
+      <xs:enumeration value="BEL"/>
+      <xs:enumeration value="BEM"/>
+      <xs:enumeration value="BEN"/>
+      <xs:enumeration value="BER"/>
+      <xs:enumeration value="BHO"/>
+      <xs:enumeration value="BIH"/>
+      <xs:enumeration value="BIK"/>
+      <xs:enumeration value="BIN"/>
+      <xs:enumeration value="BIS"/>
+      <xs:enumeration value="BLA"/>
+      <xs:enumeration value="BNT"/>
+      <xs:enumeration value="BOS"/>
+      <xs:enumeration value="BRA"/>
+      <xs:enumeration value="BRE"/>
+      <xs:enumeration value="BTK"/>
+      <xs:enumeration value="BUA"/>
+      <xs:enumeration value="BUG"/>
+      <xs:enumeration value="BUL"/>
+      <xs:enumeration value="MYA"/>
+      <xs:enumeration value="BYN"/>
+      <xs:enumeration value="CAD"/>
+      <xs:enumeration value="CAI"/>
+      <xs:enumeration value="CAR"/>
+      <xs:enumeration value="CAT"/>
+      <xs:enumeration value="CAU"/>
+      <xs:enumeration value="CEB"/>
+      <xs:enumeration value="CEL"/>
+      <xs:enumeration value="CHA"/>
+      <xs:enumeration value="CHB"/>
+      <xs:enumeration value="CHE"/>
+      <xs:enumeration value="CHG"/>
+      <xs:enumeration value="ZHO"/>
+      <xs:enumeration value="CHK"/>
+      <xs:enumeration value="CHM"/>
+      <xs:enumeration value="CHN"/>
+      <xs:enumeration value="CHO"/>
+      <xs:enumeration value="CHP"/>
+      <xs:enumeration value="CHR"/>
+      <xs:enumeration value="CHU"/>
+      <xs:enumeration value="CHV"/>
+      <xs:enumeration value="CHY"/>
+      <xs:enumeration value="CMC"/>
+      <xs:enumeration value="COP"/>
+      <xs:enumeration value="COR"/>
+      <xs:enumeration value="COS"/>
+      <xs:enumeration value="CPE"/>
+      <xs:enumeration value="CPF"/>
+      <xs:enumeration value="CPP"/>
+      <xs:enumeration value="CRE"/>
+      <xs:enumeration value="CRH"/>
+      <xs:enumeration value="CRP"/>
+      <xs:enumeration value="CSB"/>
+      <xs:enumeration value="CUS"/>
+      <xs:enumeration value="CES"/>
+      <xs:enumeration value="DAK"/>
+      <xs:enumeration value="DAN"/>
+      <xs:enumeration value="DAR"/>
+      <xs:enumeration value="DAY"/>
+      <xs:enumeration value="DEL"/>
+      <xs:enumeration value="DEN"/>
+      <xs:enumeration value="DGR"/>
+      <xs:enumeration value="DIN"/>
+      <xs:enumeration value="DIV"/>
+      <xs:enumeration value="DOI"/>
+      <xs:enumeration value="DRA"/>
+      <xs:enumeration value="DSB"/>
+      <xs:enumeration value="DUA"/>
+      <xs:enumeration value="DUM"/>
+      <xs:enumeration value="NLD"/>
+      <xs:enumeration value="DYU"/>
+      <xs:enumeration value="DZO"/>
+      <xs:enumeration value="EFI"/>
+      <xs:enumeration value="EGY"/>
+      <xs:enumeration value="EKA"/>
+      <xs:enumeration value="ELX"/>
+      <xs:enumeration value="ENG"/>
+      <xs:enumeration value="ENM"/>
+      <xs:enumeration value="EPO"/>
+      <xs:enumeration value="EST"/>
+      <xs:enumeration value="EWE"/>
+      <xs:enumeration value="EWO"/>
+      <xs:enumeration value="FAN"/>
+      <xs:enumeration value="FAO"/>
+      <xs:enumeration value="FAT"/>
+      <xs:enumeration value="FIJ"/>
+      <xs:enumeration value="FIL"/>
+      <xs:enumeration value="FIN"/>
+      <xs:enumeration value="FIU"/>
+      <xs:enumeration value="FON"/>
+      <xs:enumeration value="FRA"/>
+      <xs:enumeration value="FRM"/>
+      <xs:enumeration value="FRO"/>
+      <xs:enumeration value="FRR"/>
+      <xs:enumeration value="FRS"/>
+      <xs:enumeration value="FRY"/>
+      <xs:enumeration value="FUL"/>
+      <xs:enumeration value="FUR"/>
+      <xs:enumeration value="GAA"/>
+      <xs:enumeration value="GAY"/>
+      <xs:enumeration value="GBA"/>
+      <xs:enumeration value="GEM"/>
+      <xs:enumeration value="KAT"/>
+      <xs:enumeration value="DEU"/>
+      <xs:enumeration value="GEZ"/>
+      <xs:enumeration value="GIL"/>
+      <xs:enumeration value="GLA"/>
+      <xs:enumeration value="GLE"/>
+      <xs:enumeration value="GLG"/>
+      <xs:enumeration value="GLV"/>
+      <xs:enumeration value="GMH"/>
+      <xs:enumeration value="GOH"/>
+      <xs:enumeration value="GON"/>
+      <xs:enumeration value="GOR"/>
+      <xs:enumeration value="GOT"/>
+      <xs:enumeration value="GRB"/>
+      <xs:enumeration value="GRC"/>
+      <xs:enumeration value="ELL"/>
+      <xs:enumeration value="GRN"/>
+      <xs:enumeration value="GSW"/>
+      <xs:enumeration value="GUJ"/>
+      <xs:enumeration value="GWI"/>
+      <xs:enumeration value="HAI"/>
+      <xs:enumeration value="HAT"/>
+      <xs:enumeration value="HAU"/>
+      <xs:enumeration value="HAW"/>
+      <xs:enumeration value="HEB"/>
+      <xs:enumeration value="HER"/>
+      <xs:enumeration value="HIL"/>
+      <xs:enumeration value="HIM"/>
+      <xs:enumeration value="HIN"/>
+      <xs:enumeration value="HIT"/>
+      <xs:enumeration value="HMN"/>
+      <xs:enumeration value="HMO"/>
+      <xs:enumeration value="HRV"/>
+      <xs:enumeration value="HSB"/>
+      <xs:enumeration value="HUN"/>
+      <xs:enumeration value="HUP"/>
+      <xs:enumeration value="IBA"/>
+      <xs:enumeration value="IBO"/>
+      <xs:enumeration value="ISL"/>
+      <xs:enumeration value="IDO"/>
+      <xs:enumeration value="III"/>
+      <xs:enumeration value="IJO"/>
+      <xs:enumeration value="IKU"/>
+      <xs:enumeration value="ILE"/>
+      <xs:enumeration value="ILO"/>
+      <xs:enumeration value="INA"/>
+      <xs:enumeration value="INC"/>
+      <xs:enumeration value="IND"/>
+      <xs:enumeration value="INE"/>
+      <xs:enumeration value="INH"/>
+      <xs:enumeration value="IPK"/>
+      <xs:enumeration value="IRA"/>
+      <xs:enumeration value="IRO"/>
+      <xs:enumeration value="ITA"/>
+      <xs:enumeration value="JAV"/>
+      <xs:enumeration value="JBO"/>
+      <xs:enumeration value="JPN"/>
+      <xs:enumeration value="JPR"/>
+      <xs:enumeration value="JRB"/>
+      <xs:enumeration value="KAA"/>
+      <xs:enumeration value="KAB"/>
+      <xs:enumeration value="KAC"/>
+      <xs:enumeration value="KAL"/>
+      <xs:enumeration value="KAM"/>
+      <xs:enumeration value="KAN"/>
+      <xs:enumeration value="KAR"/>
+      <xs:enumeration value="KAS"/>
+      <xs:enumeration value="KAU"/>
+      <xs:enumeration value="KAW"/>
+      <xs:enumeration value="KAZ"/>
+      <xs:enumeration value="KBD"/>
+      <xs:enumeration value="KHA"/>
+      <xs:enumeration value="KHI"/>
+      <xs:enumeration value="KHM"/>
+      <xs:enumeration value="KHO"/>
+      <xs:enumeration value="KIK"/>
+      <xs:enumeration value="KIN"/>
+      <xs:enumeration value="KIR"/>
+      <xs:enumeration value="KMB"/>
+      <xs:enumeration value="KOK"/>
+      <xs:enumeration value="KOM"/>
+      <xs:enumeration value="KON"/>
+      <xs:enumeration value="KOR"/>
+      <xs:enumeration value="KOS"/>
+      <xs:enumeration value="KPE"/>
+      <xs:enumeration value="KRC"/>
+      <xs:enumeration value="KRL"/>
+      <xs:enumeration value="KRO"/>
+      <xs:enumeration value="KRU"/>
+      <xs:enumeration value="KUA"/>
+      <xs:enumeration value="KUM"/>
+      <xs:enumeration value="KUR"/>
+      <xs:enumeration value="KUT"/>
+      <xs:enumeration value="LAD"/>
+      <xs:enumeration value="LAH"/>
+      <xs:enumeration value="LAM"/>
+      <xs:enumeration value="LAO"/>
+      <xs:enumeration value="LAT"/>
+      <xs:enumeration value="LAV"/>
+      <xs:enumeration value="LEZ"/>
+      <xs:enumeration value="LIM"/>
+      <xs:enumeration value="LIN"/>
+      <xs:enumeration value="LIT"/>
+      <xs:enumeration value="LOL"/>
+      <xs:enumeration value="LOZ"/>
+      <xs:enumeration value="LTZ"/>
+      <xs:enumeration value="LUA"/>
+      <xs:enumeration value="LUB"/>
+      <xs:enumeration value="LUG"/>
+      <xs:enumeration value="LUI"/>
+      <xs:enumeration value="LUN"/>
+      <xs:enumeration value="LUO"/>
+      <xs:enumeration value="LUS"/>
+      <xs:enumeration value="MKD"/>
+      <xs:enumeration value="MAD"/>
+      <xs:enumeration value="MAG"/>
+      <xs:enumeration value="MAH"/>
+      <xs:enumeration value="MAI"/>
+      <xs:enumeration value="MAK"/>
+      <xs:enumeration value="MAL"/>
+      <xs:enumeration value="MAN"/>
+      <xs:enumeration value="MRI"/>
+      <xs:enumeration value="MAP"/>
+      <xs:enumeration value="MAR"/>
+      <xs:enumeration value="MAS"/>
+      <xs:enumeration value="MSA"/>
+      <xs:enumeration value="MDF"/>
+      <xs:enumeration value="MDR"/>
+      <xs:enumeration value="MEN"/>
+      <xs:enumeration value="MGA"/>
+      <xs:enumeration value="MIC"/>
+      <xs:enumeration value="MIN"/>
+      <xs:enumeration value="MKH"/>
+      <xs:enumeration value="MLG"/>
+      <xs:enumeration value="MLT"/>
+      <xs:enumeration value="MNC"/>
+      <xs:enumeration value="MNI"/>
+      <xs:enumeration value="MNO"/>
+      <xs:enumeration value="MOH"/>
+      <xs:enumeration value="MON"/>
+      <xs:enumeration value="MOS"/>
+      <xs:enumeration value="MUN"/>
+      <xs:enumeration value="MUS"/>
+      <xs:enumeration value="MWL"/>
+      <xs:enumeration value="MWR"/>
+      <xs:enumeration value="MYN"/>
+      <xs:enumeration value="MYV"/>
+      <xs:enumeration value="NAH"/>
+      <xs:enumeration value="NAI"/>
+      <xs:enumeration value="NAP"/>
+      <xs:enumeration value="NAU"/>
+      <xs:enumeration value="NAV"/>
+      <xs:enumeration value="NBL"/>
+      <xs:enumeration value="NDE"/>
+      <xs:enumeration value="NDO"/>
+      <xs:enumeration value="NDS"/>
+      <xs:enumeration value="NEP"/>
+      <xs:enumeration value="NEW"/>
+      <xs:enumeration value="NIA"/>
+      <xs:enumeration value="NIC"/>
+      <xs:enumeration value="NIU"/>
+      <xs:enumeration value="NNO"/>
+      <xs:enumeration value="NOB"/>
+      <xs:enumeration value="NOG"/>
+      <xs:enumeration value="NON"/>
+      <xs:enumeration value="NOR"/>
+      <xs:enumeration value="NQO"/>
+      <xs:enumeration value="NSO"/>
+      <xs:enumeration value="NUB"/>
+      <xs:enumeration value="NWC"/>
+      <xs:enumeration value="NYA"/>
+      <xs:enumeration value="NYM"/>
+      <xs:enumeration value="NYN"/>
+      <xs:enumeration value="NYO"/>
+      <xs:enumeration value="NZI"/>
+      <xs:enumeration value="OCI"/>
+      <xs:enumeration value="OJI"/>
+      <xs:enumeration value="ORI"/>
+      <xs:enumeration value="ORM"/>
+      <xs:enumeration value="OSA"/>
+      <xs:enumeration value="OSS"/>
+      <xs:enumeration value="OTA"/>
+      <xs:enumeration value="OTO"/>
+      <xs:enumeration value="PAA"/>
+      <xs:enumeration value="PAG"/>
+      <xs:enumeration value="PAL"/>
+      <xs:enumeration value="PAM"/>
+      <xs:enumeration value="PAN"/>
+      <xs:enumeration value="PAP"/>
+      <xs:enumeration value="PAU"/>
+      <xs:enumeration value="PEO"/>
+      <xs:enumeration value="FAS"/>
+      <xs:enumeration value="PHI"/>
+      <xs:enumeration value="PHN"/>
+      <xs:enumeration value="PLI"/>
+      <xs:enumeration value="POL"/>
+      <xs:enumeration value="PON"/>
+      <xs:enumeration value="POR"/>
+      <xs:enumeration value="PRA"/>
+      <xs:enumeration value="PRO"/>
+      <xs:enumeration value="PUS"/>
+      <xs:enumeration value="QUE"/>
+      <xs:enumeration value="RAJ"/>
+      <xs:enumeration value="RAP"/>
+      <xs:enumeration value="RAR"/>
+      <xs:enumeration value="ROA"/>
+      <xs:enumeration value="ROH"/>
+      <xs:enumeration value="ROM"/>
+      <xs:enumeration value="RON"/>
+      <xs:enumeration value="RUN"/>
+      <xs:enumeration value="RUP"/>
+      <xs:enumeration value="RUS"/>
+      <xs:enumeration value="SAD"/>
+      <xs:enumeration value="SAG"/>
+      <xs:enumeration value="SAH"/>
+      <xs:enumeration value="SAI"/>
+      <xs:enumeration value="SAL"/>
+      <xs:enumeration value="SAM"/>
+      <xs:enumeration value="SAN"/>
+      <xs:enumeration value="SAS"/>
+      <xs:enumeration value="SAT"/>
+      <xs:enumeration value="SCN"/>
+      <xs:enumeration value="SCO"/>
+      <xs:enumeration value="SEL"/>
+      <xs:enumeration value="SEM"/>
+      <xs:enumeration value="SGA"/>
+      <xs:enumeration value="SGN"/>
+      <xs:enumeration value="SHN"/>
+      <xs:enumeration value="SID"/>
+      <xs:enumeration value="SIN"/>
+      <xs:enumeration value="SIO"/>
+      <xs:enumeration value="SIT"/>
+      <xs:enumeration value="SLA"/>
+      <xs:enumeration value="SLK"/>
+      <xs:enumeration value="SLV"/>
+      <xs:enumeration value="SMA"/>
+      <xs:enumeration value="SME"/>
+      <xs:enumeration value="SMI"/>
+      <xs:enumeration value="SMJ"/>
+      <xs:enumeration value="SMN"/>
+      <xs:enumeration value="SMO"/>
+      <xs:enumeration value="SMS"/>
+      <xs:enumeration value="SNA"/>
+      <xs:enumeration value="SND"/>
+      <xs:enumeration value="SNK"/>
+      <xs:enumeration value="SOG"/>
+      <xs:enumeration value="SOM"/>
+      <xs:enumeration value="SON"/>
+      <xs:enumeration value="SOT"/>
+      <xs:enumeration value="SPA"/>
+      <xs:enumeration value="SRD"/>
+      <xs:enumeration value="SRN"/>
+      <xs:enumeration value="SRP"/>
+      <xs:enumeration value="SRR"/>
+      <xs:enumeration value="SSA"/>
+      <xs:enumeration value="SSW"/>
+      <xs:enumeration value="SUK"/>
+      <xs:enumeration value="SUN"/>
+      <xs:enumeration value="SUS"/>
+      <xs:enumeration value="SUX"/>
+      <xs:enumeration value="SWA"/>
+      <xs:enumeration value="SWE"/>
+      <xs:enumeration value="SYC"/>
+      <xs:enumeration value="SYR"/>
+      <xs:enumeration value="TAH"/>
+      <xs:enumeration value="TAI"/>
+      <xs:enumeration value="TAM"/>
+      <xs:enumeration value="TAT"/>
+      <xs:enumeration value="TEL"/>
+      <xs:enumeration value="TEM"/>
+      <xs:enumeration value="TER"/>
+      <xs:enumeration value="TET"/>
+      <xs:enumeration value="TGK"/>
+      <xs:enumeration value="TGL"/>
+      <xs:enumeration value="THA"/>
+      <xs:enumeration value="BOD"/>
+      <xs:enumeration value="TIG"/>
+      <xs:enumeration value="TIR"/>
+      <xs:enumeration value="TIV"/>
+      <xs:enumeration value="TKL"/>
+      <xs:enumeration value="TLH"/>
+      <xs:enumeration value="TLI"/>
+      <xs:enumeration value="TMH"/>
+      <xs:enumeration value="TOG"/>
+      <xs:enumeration value="TON"/>
+      <xs:enumeration value="TPI"/>
+      <xs:enumeration value="TSI"/>
+      <xs:enumeration value="TSN"/>
+      <xs:enumeration value="TSO"/>
+      <xs:enumeration value="TUK"/>
+      <xs:enumeration value="TUM"/>
+      <xs:enumeration value="TUP"/>
+      <xs:enumeration value="TUR"/>
+      <xs:enumeration value="TUT"/>
+      <xs:enumeration value="TVL"/>
+      <xs:enumeration value="TWI"/>
+      <xs:enumeration value="TYV"/>
+      <xs:enumeration value="UDM"/>
+      <xs:enumeration value="UGA"/>
+      <xs:enumeration value="UIG"/>
+      <xs:enumeration value="UKR"/>
+      <xs:enumeration value="UMB"/>
+      <xs:enumeration value="URD"/>
+      <xs:enumeration value="UZB"/>
+      <xs:enumeration value="VAI"/>
+      <xs:enumeration value="VEN"/>
+      <xs:enumeration value="VIE"/>
+      <xs:enumeration value="VOL"/>
+      <xs:enumeration value="VOT"/>
+      <xs:enumeration value="WAK"/>
+      <xs:enumeration value="WAL"/>
+      <xs:enumeration value="WAR"/>
+      <xs:enumeration value="WAS"/>
+      <xs:enumeration value="CYM"/>
+      <xs:enumeration value="WEN"/>
+      <xs:enumeration value="WLN"/>
+      <xs:enumeration value="WOL"/>
+      <xs:enumeration value="XAL"/>
+      <xs:enumeration value="XHO"/>
+      <xs:enumeration value="YAO"/>
+      <xs:enumeration value="YAP"/>
+      <xs:enumeration value="YID"/>
+      <xs:enumeration value="YOR"/>
+      <xs:enumeration value="YPK"/>
+      <xs:enumeration value="ZAP"/>
+      <xs:enumeration value="ZBL"/>
+      <xs:enumeration value="ZEN"/>
+      <xs:enumeration value="ZHA"/>
+      <xs:enumeration value="ZND"/>
+      <xs:enumeration value="ZUL"/>
+      <xs:enumeration value="ZUN"/>
+      <xs:enumeration value="ZZA"/>
+      <xs:enumeration value="MIS"/>
+      <xs:enumeration value="MUL"/>
+      <xs:enumeration value="UND"/>
+      <xs:enumeration value="ZXX"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="languageIso1Type" id="languageIso1Type">
+    <xs:annotation>
+      <xs:documentation>Two-letter ISO 639-1 language code.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="AB"/>
+      <xs:enumeration value="AA"/>
+      <xs:enumeration value="AF"/>
+      <xs:enumeration value="AK"/>
+      <xs:enumeration value="SQ"/>
+      <xs:enumeration value="AM"/>
+      <xs:enumeration value="AR"/>
+      <xs:enumeration value="AN"/>
+      <xs:enumeration value="HY"/>
+      <xs:enumeration value="AS"/>
+      <xs:enumeration value="AV"/>
+      <xs:enumeration value="AE"/>
+      <xs:enumeration value="AY"/>
+      <xs:enumeration value="AZ"/>
+      <xs:enumeration value="BM"/>
+      <xs:enumeration value="BA"/>
+      <xs:enumeration value="EU"/>
+      <xs:enumeration value="BE"/>
+      <xs:enumeration value="BN"/>
+      <xs:enumeration value="BI"/>
+      <xs:enumeration value="BS"/>
+      <xs:enumeration value="BR"/>
+      <xs:enumeration value="BG"/>
+      <xs:enumeration value="MY"/>
+      <xs:enumeration value="CA"/>
+      <xs:enumeration value="CH"/>
+      <xs:enumeration value="CE"/>
+      <xs:enumeration value="NY"/>
+      <xs:enumeration value="ZH"/>
+      <xs:enumeration value="CU"/>
+      <xs:enumeration value="CV"/>
+      <xs:enumeration value="KW"/>
+      <xs:enumeration value="CO"/>
+      <xs:enumeration value="CR"/>
+      <xs:enumeration value="HR"/>
+      <xs:enumeration value="CS"/>
+      <xs:enumeration value="DA"/>
+      <xs:enumeration value="DV"/>
+      <xs:enumeration value="NL"/>
+      <xs:enumeration value="DZ"/>
+      <xs:enumeration value="EN"/>
+      <xs:enumeration value="EO"/>
+      <xs:enumeration value="ET"/>
+      <xs:enumeration value="EE"/>
+      <xs:enumeration value="FO"/>
+      <xs:enumeration value="FJ"/>
+      <xs:enumeration value="FI"/>
+      <xs:enumeration value="FR"/>
+      <xs:enumeration value="FY"/>
+      <xs:enumeration value="FF"/>
+      <xs:enumeration value="GD"/>
+      <xs:enumeration value="GL"/>
+      <xs:enumeration value="LG"/>
+      <xs:enumeration value="KA"/>
+      <xs:enumeration value="DE"/>
+      <xs:enumeration value="EL"/>
+      <xs:enumeration value="KL"/>
+      <xs:enumeration value="GN"/>
+      <xs:enumeration value="GU"/>
+      <xs:enumeration value="HT"/>
+      <xs:enumeration value="HA"/>
+      <xs:enumeration value="HE"/>
+      <xs:enumeration value="HZ"/>
+      <xs:enumeration value="HI"/>
+      <xs:enumeration value="HO"/>
+      <xs:enumeration value="HU"/>
+      <xs:enumeration value="IS"/>
+      <xs:enumeration value="IO"/>
+      <xs:enumeration value="IG"/>
+      <xs:enumeration value="ID"/>
+      <xs:enumeration value="IA"/>
+      <xs:enumeration value="IE"/>
+      <xs:enumeration value="IU"/>
+      <xs:enumeration value="IK"/>
+      <xs:enumeration value="GA"/>
+      <xs:enumeration value="IT"/>
+      <xs:enumeration value="JA"/>
+      <xs:enumeration value="JV"/>
+      <xs:enumeration value="KN"/>
+      <xs:enumeration value="KR"/>
+      <xs:enumeration value="KS"/>
+      <xs:enumeration value="KK"/>
+      <xs:enumeration value="KM"/>
+      <xs:enumeration value="KI"/>
+      <xs:enumeration value="RW"/>
+      <xs:enumeration value="KY"/>
+      <xs:enumeration value="KV"/>
+      <xs:enumeration value="KG"/>
+      <xs:enumeration value="KO"/>
+      <xs:enumeration value="KJ"/>
+      <xs:enumeration value="KU"/>
+      <xs:enumeration value="LO"/>
+      <xs:enumeration value="LA"/>
+      <xs:enumeration value="LV"/>
+      <xs:enumeration value="LI"/>
+      <xs:enumeration value="LN"/>
+      <xs:enumeration value="LT"/>
+      <xs:enumeration value="LU"/>
+      <xs:enumeration value="LB"/>
+      <xs:enumeration value="MK"/>
+      <xs:enumeration value="MG"/>
+      <xs:enumeration value="MS"/>
+      <xs:enumeration value="ML"/>
+      <xs:enumeration value="MT"/>
+      <xs:enumeration value="GV"/>
+      <xs:enumeration value="MI"/>
+      <xs:enumeration value="MR"/>
+      <xs:enumeration value="MH"/>
+      <xs:enumeration value="MN"/>
+      <xs:enumeration value="NA"/>
+      <xs:enumeration value="NV"/>
+      <xs:enumeration value="ND"/>
+      <xs:enumeration value="NR"/>
+      <xs:enumeration value="NG"/>
+      <xs:enumeration value="NE"/>
+      <xs:enumeration value="NO"/>
+      <xs:enumeration value="NB"/>
+      <xs:enumeration value="NN"/>
+      <xs:enumeration value="II"/>
+      <xs:enumeration value="OC"/>
+      <xs:enumeration value="OJ"/>
+      <xs:enumeration value="OR"/>
+      <xs:enumeration value="OM"/>
+      <xs:enumeration value="OS"/>
+      <xs:enumeration value="PI"/>
+      <xs:enumeration value="PS"/>
+      <xs:enumeration value="FA"/>
+      <xs:enumeration value="PL"/>
+      <xs:enumeration value="PT"/>
+      <xs:enumeration value="PA"/>
+      <xs:enumeration value="QU"/>
+      <xs:enumeration value="RO"/>
+      <xs:enumeration value="RM"/>
+      <xs:enumeration value="RN"/>
+      <xs:enumeration value="RU"/>
+      <xs:enumeration value="SE"/>
+      <xs:enumeration value="SM"/>
+      <xs:enumeration value="SG"/>
+      <xs:enumeration value="SA"/>
+      <xs:enumeration value="SC"/>
+      <xs:enumeration value="SR"/>
+      <xs:enumeration value="SN"/>
+      <xs:enumeration value="SD"/>
+      <xs:enumeration value="SI"/>
+      <xs:enumeration value="SK"/>
+      <xs:enumeration value="SL"/>
+      <xs:enumeration value="SO"/>
+      <xs:enumeration value="ST"/>
+      <xs:enumeration value="ES"/>
+      <xs:enumeration value="SU"/>
+      <xs:enumeration value="SW"/>
+      <xs:enumeration value="SS"/>
+      <xs:enumeration value="SV"/>
+      <xs:enumeration value="TL"/>
+      <xs:enumeration value="TY"/>
+      <xs:enumeration value="TG"/>
+      <xs:enumeration value="TA"/>
+      <xs:enumeration value="TT"/>
+      <xs:enumeration value="TE"/>
+      <xs:enumeration value="TH"/>
+      <xs:enumeration value="BO"/>
+      <xs:enumeration value="TI"/>
+      <xs:enumeration value="TO"/>
+      <xs:enumeration value="TS"/>
+      <xs:enumeration value="TN"/>
+      <xs:enumeration value="TR"/>
+      <xs:enumeration value="TK"/>
+      <xs:enumeration value="TW"/>
+      <xs:enumeration value="UG"/>
+      <xs:enumeration value="UK"/>
+      <xs:enumeration value="UR"/>
+      <xs:enumeration value="UZ"/>
+      <xs:enumeration value="VE"/>
+      <xs:enumeration value="VI"/>
+      <xs:enumeration value="VO"/>
+      <xs:enumeration value="WA"/>
+      <xs:enumeration value="CY"/>
+      <xs:enumeration value="WO"/>
+      <xs:enumeration value="XH"/>
+      <xs:enumeration value="YI"/>
+      <xs:enumeration value="YO"/>
+      <xs:enumeration value="ZA"/>
+      <xs:enumeration value="ZU"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>
-

--- a/jmef_1.0_example.xml
+++ b/jmef_1.0_example.xml
@@ -1,4 +1,4 @@
-<journal owner-type="scholar">
+<journal xmlns:xlink="http://www.w3.org/1999/xlink" owner-type="scholar">
   <journal-id journal-id-type="ddh">123</journal-id>
   <journal-id journal-id-type="doaj">6f0107092faa43e7b3232480cb89fb99</journal-id>
   <journal-id journal-id-type="doi">10.1012/abc</journal-id>
@@ -20,8 +20,8 @@
     </costs>
     <review-process peer-review="true" />
     <languages>
-      <language iso2="EN" iso3="ENG">English</language>
-      <language iso2="DE">German</language>
+      <language iso1="EN" iso2="ENG">English</language>
+      <language iso1="DE">German</language>
       <language>Polish</language>
     </languages>
     <licenses>


### PR DESCRIPTION
I've also made small change in xml:
 - added definition for `xlink`
 - changed `iso3` to `iso2` (formally ISO_639-2)  and `iso2` to `iso1` (formally ISO 639-1) in case of language codes.