### PR TITLE
Update jmef schema

### DIFF
--- a/jmef.xsd
+++ b/jmef.xsd
@@ -5,20 +5,20 @@
     <xs:complexType>
       <xs:sequence>
 
-        <xs:element minOccurs="0" maxOccurs="unbounded" name="journal-id">
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="id">
           <xs:complexType>
             <xs:simpleContent>
               <xs:extension base="xs:string">
-                <xs:attribute name="journal-id-type" type="xs:string" use="required"/>
+                <xs:attribute name="type" type="xs:string" use="required"/>
               </xs:extension>
             </xs:simpleContent>
           </xs:complexType>
         </xs:element>
 
-        <xs:element name="journal-title-group">
+        <xs:element name="title-group">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="journal-title">
+              <xs:element name="title">
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
@@ -27,16 +27,7 @@
                   </xs:simpleContent>
                 </xs:complexType>
               </xs:element>
-              <xs:element name="journal-title-translation" minOccurs="0" maxOccurs="unbounded">
-                <xs:complexType>
-                  <xs:simpleContent>
-                    <xs:extension base="xs:string">
-                      <xs:attribute name="language-iso2" type="languageIso2Type" use="required"/>
-                    </xs:extension>
-                  </xs:simpleContent>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="journal-other-title" minOccurs="0" maxOccurs="unbounded">
+              <xs:element name="other-title" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
@@ -118,8 +109,8 @@
               <xs:element minOccurs="0" name="publisher">
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element minOccurs="0" name="publisher-name" type="xs:string"/>
-                    <xs:element minOccurs="0" name="publisher-location">
+                    <xs:element minOccurs="0" name="name" type="xs:string"/>
+                    <xs:element minOccurs="0" name="location">
                       <xs:complexType>
                         <xs:sequence>
                           <xs:element name="country">
@@ -151,11 +142,6 @@
         <xs:element minOccurs="0" name="publication-policy">
           <xs:complexType>
             <xs:sequence>
-              <xs:element minOccurs="0" name="fees">
-                <xs:complexType>
-                  <xs:attribute name="free" type="xs:boolean" use="required"/>
-                </xs:complexType>
-              </xs:element>
               <xs:element minOccurs="0" name="review-process">
                 <xs:complexType>
                   <xs:attribute name="type" type="reviewType" use="required"/>
@@ -187,11 +173,6 @@
                   </xs:sequence>
                 </xs:complexType>
               </xs:element>
-              <xs:element minOccurs="0" name="authorship">
-                <xs:complexType>
-                  <xs:attribute name="open" type="xs:boolean" use="required"/>
-                </xs:complexType>
-              </xs:element>
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -202,28 +183,35 @@
           </xs:complexType>
         </xs:element>
 
-        <xs:element minOccurs="0" maxOccurs="unbounded" name="kwd-group">
+        <xs:element minOccurs="0" name="keywords">
           <xs:complexType>
             <xs:sequence>
-              <xs:element minOccurs="0" name="compound-kwd">
+              <xs:element minOccurs="0" maxOccurs="unbounded" name="keyword" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element minOccurs="0" name="classifications">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element minOccurs="0" maxOccurs="unbounded" name="classification">
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element maxOccurs="unbounded" name="compound-kwd-part">
+                    <xs:element minOccurs="0" maxOccurs="unbounded" name="class">
                       <xs:complexType>
                         <xs:simpleContent>
                           <xs:extension base="xs:string">
-                            <xs:attribute name="content-type" type="xs:string" use="required"/>
+		            <xs:attribute name="code" type="xs:string" use="required"/>
+			    <xs:attribute name="value" type="xs:string" use="optional"/>
                           </xs:extension>
                         </xs:simpleContent>
                       </xs:complexType>
                     </xs:element>
-                  </xs:sequence>
+	          </xs:sequence>
+	          <xs:attribute name="tyoe" type="xs:string" use="optional"/>
                 </xs:complexType>
               </xs:element>
-              <xs:element minOccurs="0" maxOccurs="unbounded" name="kwd" type="xs:string"/>
             </xs:sequence>
-            <xs:attribute name="vocab" type="xs:string" use="optional"/>
-            <xs:attribute name="vocab-identifier" type="xs:string" use="optional"/>
           </xs:complexType>
         </xs:element>
       </xs:sequence>

--- a/jmef.xsd
+++ b/jmef.xsd
@@ -131,7 +131,7 @@
               <xs:element minOccurs="0" maxOccurs="unbounded" name="other-organization">
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element name="organization-name" type="xs:string"/>
+                    <xs:element name="name" type="xs:string"/>
                   </xs:sequence>
                 </xs:complexType>
               </xs:element>
@@ -208,7 +208,7 @@
                       </xs:complexType>
                     </xs:element>
 	          </xs:sequence>
-	          <xs:attribute name="tyoe" type="xs:string" use="optional"/>
+	          <xs:attribute name="type" type="xs:string" use="optional"/>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
@@ -222,6 +222,7 @@
       <xs:documentation>Type of other title.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
+      <xs:enumeration value="translation"/>
       <xs:enumeration value="alternative"/>
       <xs:enumeration value="subtitle"/>
       <xs:enumeration value="other"/>

--- a/jmef_1.0_example.xml
+++ b/jmef_1.0_example.xml
@@ -1,13 +1,13 @@
 <journal xmlns:xlink="http://www.w3.org/1999/xlink">
-  <journal-id journal-id-type="ddh">123</journal-id>
-  <journal-id journal-id-type="doaj">6f0107092faa43e7b3232480cb89fb99</journal-id>
-  <journal-id journal-id-type="doi">10.1012/abc</journal-id>
-  <journal-title-group>
-    <journal-title language-iso2="ENG">Patria Artha Technological Journal</journal-title>
-    <journal-title-translation language-iso2="DEU">Translated title</journal-title-translation>
-    <journal-other-title type="subtitle" language-iso2="ENG">Subtitle</journal-other-title>
-    <journal-other-title type="alternative">Alt title</journal-other-title>
-  </journal-title-group>
+  <id type="ddh">123</id>
+  <id type="doaj">6f0107092faa43e7b3232480cb89fb99</journal-id>
+  <id type="doi">10.1012/abc</journal-id>
+  <title-group>
+    <title language-iso2="ENG">Patria Artha Technological Journal</title>
+    <other-title type="translation" language-iso2="DEU">Translated title</other-title>
+    <other-title type="subtitle" language-iso2="ENG">Subtitle</other-title>
+    <other-title type="alternative">Alt title</other-title>
+  </title-group>
   <issn publication-format="print">1063-777X</issn>
   <issn publication-format="electronic">1090-6517</issn> 
 
@@ -21,21 +21,20 @@
 
   <organizations>
     <publisher>
-      <publisher-name>British Medical Journal</publisher-name>
-      <publisher-location>
+      <name>British Medical Journal</name>
+      <location>
         <country iso3="GBR">United Kingdom</country>
-      </publisher-location>
+      </location>
     </publisher>
     <other-organization>
-      <organization-name>University of Science</organization-name>
+      <name>University of Science</name>
     </other-organization>
     <other-organization>
-      <organization-name>University of Science 2</organization-name>
+      <name>University of Science 2</name>
     </other-organization>
   </organizations>
 
   <publication-policy>
-    <fees free="true"/>
     <review-process type="peer"/>
     <languages>
       <language iso2="ENG">English</language>
@@ -46,19 +45,17 @@
       <license xlink:href="http://creativecommons.org/licenses/by-nc/4.0" />
       <license xlink:href="http://creativecommons.org/licenses/by/4.0" />
     </licenses>
-    <authorship open="true" />
   </publication-policy>
   <self-uri xlink:href="http://ejournal.patria-artha.ac.id/index.php/patj/index" />
-  <kwd-group>
-    <kwd>DNA analysis</kwd>
-    <kwd>gene expression</kwd>
-    <kwd>parallel cloning</kwd>
-    <kwd>fluid microarray</kwd>
-  </kwd-group>
-  <kwd-group vocab="oecd-2007" vocab-identifier="https://www.oecd.org"> 
-    <compound-kwd>
-      <compound-kwd-part content-type="code">2.6</compound-kwd-part>
-      <compound-kwd-part content-type="value">Medical engineering</compound-kwd-part>
-    </compound-kwd>
-  </kwd-group>
+  <keywords>
+    <keyword>DNA analysis</keyword>
+    <keyword>gene expression</keyword>
+    <keyword>parallel cloning</keyword>
+    <keyword>fluid microarray</keyword>
+  </keywords>
+  <classifications>
+    <classification type="oecd-2007">
+      <class code="2.6" value="Medical engineering" />
+    </classification>
+  </classifications>
 </journal>

--- a/jmef_1.0_example.xml
+++ b/jmef_1.0_example.xml
@@ -1,7 +1,7 @@
 <journal xmlns:xlink="http://www.w3.org/1999/xlink">
   <id type="ddh">123</id>
-  <id type="doaj">6f0107092faa43e7b3232480cb89fb99</journal-id>
-  <id type="doi">10.1012/abc</journal-id>
+  <id type="doaj">6f0107092faa43e7b3232480cb89fb99</id>
+  <id type="doi">10.1012/abc</id>
   <title-group>
     <title language-iso2="ENG">Patria Artha Technological Journal</title>
     <other-title type="translation" language-iso2="DEU">Translated title</other-title>


### PR DESCRIPTION
Changes include
 - removing `journal-` prefixes from tag names and attributes
 - adding envelope keywords tag for keyword
 - separate keywords and classfications
 - removed <journal-title-translation> - now it is possible to add translation using <other-title>
